### PR TITLE
updating mapping selection behavior

### DIFF
--- a/news/change_mapping_selection_behavior.rst
+++ b/news/change_mapping_selection_behavior.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* If multiple mappers are passed to a network planner, but no scorer, the *first* mappping from the *first* mapper provided will be used. This is a change from the previous behavior, which would use the *first* mapping from the *last* mapper. The current behavior is now consistent with ``openfe``\'s network planning behavior.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/konnektor/network_planners/NetworkPlanner.py
+++ b/src/konnektor/network_planners/NetworkPlanner.py
@@ -37,7 +37,7 @@ class NetworkPlanner(abc.ABC):
             self._mappers = None
         else:
             raise ValueError("Atom mappers are not the required type!")
-        
+
         self.scorer = scorer
 
     def __call__(self, *args, **kwargs) -> LigandNetwork:

--- a/src/konnektor/network_planners/NetworkPlanner.py
+++ b/src/konnektor/network_planners/NetworkPlanner.py
@@ -37,6 +37,7 @@ class NetworkPlanner(abc.ABC):
             self._mappers = None
         else:
             raise ValueError("Atom mappers are not the required type!")
+        
         self.scorer = scorer
 
     def __call__(self, *args, **kwargs) -> LigandNetwork:

--- a/src/konnektor/network_planners/_map_scoring.py
+++ b/src/konnektor/network_planners/_map_scoring.py
@@ -62,6 +62,7 @@ def _determine_best_mapping(
             try:
                 warnings.warn("Multiple mappers were provided, but no scorer. Only the first mapper provided will be used.")
                 best_mapping = next(mapping_generator)
+                break
             except:  # TODO: I don't think this except is needed
                 continue
 

--- a/src/konnektor/network_planners/_map_scoring.py
+++ b/src/konnektor/network_planners/_map_scoring.py
@@ -4,6 +4,7 @@
 import functools
 import multiprocessing as mult
 from collections.abc import Callable
+import warnings
 
 from gufe import AtomMapper, AtomMapping, SmallMoleculeComponent
 from tqdm.auto import tqdm
@@ -59,6 +60,7 @@ def _determine_best_mapping(
                     best_mapping = tmp_best_mapping
         else:
             try:
+                warnings.warn("Multiple mappers were provided, but no scorer. Only the first mapper provided will be used.")
                 best_mapping = next(mapping_generator)
             except:  # TODO: I don't think this except is needed
                 continue

--- a/src/konnektor/network_planners/_map_scoring.py
+++ b/src/konnektor/network_planners/_map_scoring.py
@@ -43,7 +43,7 @@ def _determine_best_mapping(
     for mapper in mappers:
         try:
             mapping_generator = mapper.suggest_mappings(molA, molB)
-        except:  # TODO: fix this bare except
+        except:  # TODO: I don't like this bare except
             continue
 
         if scorer:
@@ -60,7 +60,7 @@ def _determine_best_mapping(
                     best_mapping = tmp_best_mapping
         else:
             try:
-                warnings.warn("Multiple mappers were provided, but no scorer. Only the first mapper provided will be used.")
+                warnings.warn(f"Multiple mappers were provided, but no scorer. Only the first mapper provided will be used: {mapper}")
                 best_mapping = next(mapping_generator)
                 break
             except:  # TODO: I don't think this except is needed

--- a/src/konnektor/network_planners/_map_scoring.py
+++ b/src/konnektor/network_planners/_map_scoring.py
@@ -42,7 +42,7 @@ def _determine_best_mapping(
     for mapper in mappers:
         try:
             mapping_generator = mapper.suggest_mappings(molA, molB)
-        except:
+        except:  # TODO: fix this bare except
             continue
 
         if scorer:

--- a/src/konnektor/network_planners/_map_scoring.py
+++ b/src/konnektor/network_planners/_map_scoring.py
@@ -3,8 +3,8 @@
 
 import functools
 import multiprocessing as mult
-from collections.abc import Callable
 import warnings
+from collections.abc import Callable
 
 from gufe import AtomMapper, AtomMapping, SmallMoleculeComponent
 from tqdm.auto import tqdm
@@ -60,7 +60,9 @@ def _determine_best_mapping(
                     best_mapping = tmp_best_mapping
         else:
             try:
-                warnings.warn(f"Multiple mappers were provided, but no scorer. Only the first mapper provided will be used: {mapper}")
+                warnings.warn(
+                    f"Multiple mappers were provided, but no scorer. Only the first mapper provided will be used: {mapper}"
+                )
                 best_mapping = next(mapping_generator)
                 break
             except:  # TODO: I don't think this except is needed

--- a/src/konnektor/network_planners/generators/star_network_generator.py
+++ b/src/konnektor/network_planners/generators/star_network_generator.py
@@ -38,10 +38,11 @@ class StarNetworkGenerator(NetworkGenerator):
 
         Parameters
         ----------
-        mapper : AtomMapper
+        mappers : AtomMapper or list of AtomMappers
             the atom mapper is required, to define the connection between two ligands.
         scorer : AtomMappingScorer
-            scoring function evaluating an atom mapping, and giving a score between [0,1].
+            Callable which returns a float between [0,1] for any LigandAtomMapping.
+            Used to assign scores to potential mappings; higher scores indicate better mappings.
         n_processes: int, optional
             number of processes that can be used for the network generation. (default: 1)
         progress: bool, optional

--- a/src/konnektor/network_planners/generators/star_network_generator.py
+++ b/src/konnektor/network_planners/generators/star_network_generator.py
@@ -151,6 +151,7 @@ class StarNetworkGenerator(NetworkGenerator):
                             warnings.warn(
                                 f"Multiple mappers were provided, but no scorer. Only the first mapper provided will be used: {mapper}"
                             )
+                            best_mapping = next(mapping_generator)
                             break
                         except:
                             continue

--- a/src/konnektor/network_planners/generators/star_network_generator.py
+++ b/src/konnektor/network_planners/generators/star_network_generator.py
@@ -6,6 +6,7 @@ from collections.abc import Iterable
 
 from gufe import AtomMapper, Component, LigandNetwork
 from tqdm import tqdm
+import warnings
 
 from konnektor.network_planners._networkx_implementations import RadialNetworkAlgorithm
 
@@ -32,7 +33,7 @@ class StarNetworkGenerator(NetworkGenerator):
 
         The Star Network is most edge efficient, but not most graph score efficient, as it has to find a
         central `Component`, which usually is a compromise for all 'Component's.
-        From a robustness point of view, the Star Network, will immediatly be disconnected if one `Transformation` fails.
+        From a robustness point of view, the Star Network, will immediately be disconnected if one `Transformation` fails.
         However the loss of `Component` s is very limited, as only one ligand is lost per `Transformation` failure.
 
         Parameters
@@ -146,7 +147,10 @@ class StarNetworkGenerator(NetworkGenerator):
                                 best_mapping = tmp_best_mapping
                     else:
                         try:
+                            # TODO: output which mapper is first?
+                            warnings.warn("Multiple mappers were provided, but no scorer. Only the first mapper provided will be used.")
                             best_mapping = next(mapping_generator)
+                            break
                         except:
                             continue
                 if best_mapping is not None:

--- a/src/konnektor/network_planners/generators/star_network_generator.py
+++ b/src/konnektor/network_planners/generators/star_network_generator.py
@@ -2,11 +2,11 @@
 # For details, see https://github.com/OpenFreeEnergy/konnektor
 
 import functools
+import warnings
 from collections.abc import Iterable
 
 from gufe import AtomMapper, Component, LigandNetwork
 from tqdm import tqdm
-import warnings
 
 from konnektor.network_planners._networkx_implementations import RadialNetworkAlgorithm
 
@@ -147,9 +147,10 @@ class StarNetworkGenerator(NetworkGenerator):
                                 best_mapping = tmp_best_mapping
                     else:
                         try:
-                            # TODO: output which mapper is first?
-                            warnings.warn("Multiple mappers were provided, but no scorer. Only the first mapper provided will be used.")
-                            best_mapping = next(mapping_generator)
+                            # TODO: this is duplicated code, use _map_scoring
+                            warnings.warn(
+                                f"Multiple mappers were provided, but no scorer. Only the first mapper provided will be used: {mapper}"
+                            )
                             break
                         except:
                             continue

--- a/src/konnektor/tests/network_planners/conf.py
+++ b/src/konnektor/tests/network_planners/conf.py
@@ -59,7 +59,14 @@ class GenAtomMapper(DummyAtomMapper):
             componentB,
             componentA_to_componentB={k: v for k, v in zip(atomsA, atomsB)},
         )
+class BadMultiMapper(DummyAtomMapper):
+    """Test mapper that yields multiple mapping suggestions."""
+    def suggest_mappings(
+        self, componentA: SmallMoleculeComponent, componentB: SmallMoleculeComponent
+    ):
 
+        for i in range(2, 4):  # arbitrary integers, useful for testing
+            yield LigandAtomMapping(componentA, componentB, componentA_to_componentB={0: i})
 
 class BadMapper(DummyAtomMapper):
     def suggest_mappings(

--- a/src/konnektor/tests/network_planners/conf.py
+++ b/src/konnektor/tests/network_planners/conf.py
@@ -59,14 +59,17 @@ class GenAtomMapper(DummyAtomMapper):
             componentB,
             componentA_to_componentB={k: v for k, v in zip(atomsA, atomsB)},
         )
+
+
 class BadMultiMapper(DummyAtomMapper):
     """Test mapper that yields multiple mapping suggestions."""
+
     def suggest_mappings(
         self, componentA: SmallMoleculeComponent, componentB: SmallMoleculeComponent
     ):
-
         for i in range(2, 4):  # arbitrary integers, useful for testing
             yield LigandAtomMapping(componentA, componentB, componentA_to_componentB={0: i})
+
 
 class BadMapper(DummyAtomMapper):
     def suggest_mappings(

--- a/src/konnektor/tests/network_planners/generators/test_heuristic_maximal_network_planner.py
+++ b/src/konnektor/tests/network_planners/generators/test_heuristic_maximal_network_planner.py
@@ -38,7 +38,7 @@ def test_generate_maximal_network(with_progress, n_process):
 
 @pytest.mark.parametrize("with_progress", [True, False])
 @pytest.mark.parametrize("n_process", [1, 2])
-def test_generate_heuristic_maximal_network_missing_scorer(with_progress, n_process):
+def test_generate_heuristic_maximal_network_no_scorer(with_progress, n_process):
     """If no scorer is provided, the first mapping of the first mapper should be used."""
     n_compounds = 4
     components, _, _ = build_random_dataset(n_compounds=n_compounds)

--- a/src/konnektor/tests/network_planners/generators/test_heuristic_maximal_network_planner.py
+++ b/src/konnektor/tests/network_planners/generators/test_heuristic_maximal_network_planner.py
@@ -7,6 +7,7 @@ from konnektor.network_analysis import get_is_connected
 from konnektor.network_planners import HeuristicMaximalNetworkGenerator
 from konnektor.tests.network_planners.conf import (
     BadMapper,
+    BadMultiMapper,
     GenAtomMapper,
     SuperBadMapper,
 )
@@ -35,18 +36,15 @@ def test_generate_maximal_network(with_progress, n_process):
     assert len(network.edges) > n_compounds
     assert get_is_connected(network)
 
-
-@pytest.mark.parametrize("n_process", [1, 2])
 @pytest.mark.parametrize("with_progress", [True, False])
+@pytest.mark.parametrize("n_process", [1, 2])
 def test_generate_maximal_network_missing_scorer(with_progress, n_process):
-    """If no scorer is provided, the first mapping of the last mapper should be used.
-    Note: this test isn't great because BadMapper only returns one mapping
-    """
+    """If no scorer is provided, the first mapping of the first mapper should be used."""
     n_compounds = 4
     components, _, _ = build_random_dataset(n_compounds=n_compounds)
 
     planner = HeuristicMaximalNetworkGenerator(
-        mappers=[SuperBadMapper(), GenAtomMapper(), BadMapper()],
+        mappers=[BadMultiMapper(), SuperBadMapper(), BadMapper()],
         scorer=None,
         n_samples=3,
         progress=with_progress,
@@ -61,4 +59,5 @@ def test_generate_maximal_network_missing_scorer(with_progress, n_process):
     assert len(network.edges) > n_compounds
     assert get_is_connected(network)
 
-    assert [e.componentA_to_componentB for e in network.edges] == len(network.edges) * [{0: 0}]
+    # it should use the first mapper, which is BadMultiMapper
+    assert [e.componentA_to_componentB for e in network.edges] == len(network.edges) * [{0: 4}]

--- a/src/konnektor/tests/network_planners/generators/test_heuristic_maximal_network_planner.py
+++ b/src/konnektor/tests/network_planners/generators/test_heuristic_maximal_network_planner.py
@@ -8,7 +8,6 @@ from konnektor.network_planners import HeuristicMaximalNetworkGenerator
 from konnektor.tests.network_planners.conf import (
     BadMapper,
     BadMultiMapper,
-    GenAtomMapper,
     SuperBadMapper,
 )
 from konnektor.utils.toy_data import build_random_dataset
@@ -36,6 +35,7 @@ def test_generate_maximal_network(with_progress, n_process):
     assert len(network.edges) > n_compounds
     assert get_is_connected(network)
 
+
 @pytest.mark.parametrize("with_progress", [True, False])
 @pytest.mark.parametrize("n_process", [1, 2])
 def test_generate_heuristic_maximal_network_missing_scorer(with_progress, n_process):
@@ -50,10 +50,11 @@ def test_generate_heuristic_maximal_network_missing_scorer(with_progress, n_proc
         progress=with_progress,
         n_processes=n_process,
     )
+    # with pytest.warns(match="Only the first mapper provided will be used: <BadMulti"):
+    # TODO: warning isn't working with multiprocessing
     network = planner.generate_ligand_network(components)
 
     assert len(network.nodes) == n_compounds
-
     edge_count = n_compounds * 3
     assert len(network.edges) <= edge_count
     assert len(network.edges) > n_compounds

--- a/src/konnektor/tests/network_planners/generators/test_heuristic_maximal_network_planner.py
+++ b/src/konnektor/tests/network_planners/generators/test_heuristic_maximal_network_planner.py
@@ -60,4 +60,4 @@ def test_generate_maximal_network_missing_scorer(with_progress, n_process):
     assert get_is_connected(network)
 
     # it should use the first mapper, which is BadMultiMapper
-    assert [e.componentA_to_componentB for e in network.edges] == len(network.edges) * [{0: 4}]
+    assert [e.componentA_to_componentB for e in network.edges] == len(network.edges) * [{0: 2}]

--- a/src/konnektor/tests/network_planners/generators/test_heuristic_maximal_network_planner.py
+++ b/src/konnektor/tests/network_planners/generators/test_heuristic_maximal_network_planner.py
@@ -38,7 +38,7 @@ def test_generate_maximal_network(with_progress, n_process):
 
 @pytest.mark.parametrize("with_progress", [True, False])
 @pytest.mark.parametrize("n_process", [1, 2])
-def test_generate_maximal_network_missing_scorer(with_progress, n_process):
+def test_generate_heuristic_maximal_network_missing_scorer(with_progress, n_process):
     """If no scorer is provided, the first mapping of the first mapper should be used."""
     n_compounds = 4
     components, _, _ = build_random_dataset(n_compounds=n_compounds)
@@ -59,5 +59,5 @@ def test_generate_maximal_network_missing_scorer(with_progress, n_process):
     assert len(network.edges) > n_compounds
     assert get_is_connected(network)
 
-    # it should use the first mapper, which is BadMultiMapper
+    # it should use the mapping ({0:2}) of the first mapper (BadMultiMapper)
     assert [e.componentA_to_componentB for e in network.edges] == len(network.edges) * [{0: 2}]

--- a/src/konnektor/tests/network_planners/generators/test_heuristic_maximal_network_planner.py
+++ b/src/konnektor/tests/network_planners/generators/test_heuristic_maximal_network_planner.py
@@ -40,6 +40,7 @@ def test_generate_maximal_network(with_progress, n_process):
 @pytest.mark.parametrize("n_process", [1, 2])
 def test_generate_heuristic_maximal_network_no_scorer(with_progress, n_process):
     """If no scorer is provided, the first mapping of the first mapper should be used."""
+    # TODO: what if the first mapper fails? should this be the first *valid* mapper (current behavior), or just error out?
     n_compounds = 4
     components, _, _ = build_random_dataset(n_compounds=n_compounds)
 

--- a/src/konnektor/tests/network_planners/generators/test_maximal_network_planner.py
+++ b/src/konnektor/tests/network_planners/generators/test_maximal_network_planner.py
@@ -65,7 +65,7 @@ def test_generate_maximal_network_mapper_error(toluene_vs_others, n_process, wit
 
 @pytest.mark.parametrize("n_process", [1, 2])
 @pytest.mark.parametrize("with_progress", [True, False])
-def test_generate_maximal_network_missing_scorer(toluene_vs_others, n_process, with_progress):
+def test_generate_maximal_network_no_scorer(toluene_vs_others, n_process, with_progress):
     """If no scorer is provided, the first mapping of the first mapper should be used."""
     toluene, others = toluene_vs_others
     components = others + [toluene]

--- a/src/konnektor/tests/network_planners/generators/test_maximal_network_planner.py
+++ b/src/konnektor/tests/network_planners/generators/test_maximal_network_planner.py
@@ -6,9 +6,9 @@ import pytest
 from konnektor.network_planners import MaximalNetworkGenerator
 from konnektor.tests.network_planners.conf import (
     BadMapper,
+    BadMultiMapper,
     ErrorMapper,
     GenAtomMapper,
-    BadMultiMapper,
     SuperBadMapper,
     genScorer,
 )
@@ -76,8 +76,10 @@ def test_generate_maximal_network_missing_scorer(toluene_vs_others, n_process, w
         progress=with_progress,
         n_processes=n_process,
     )
-    with pytest.warns():
-        network = planner.generate_ligand_network(components)
+    # with pytest.warns(match="Only the first mapper provided will be used: <BadMulti"):
+    # TODO: warning isn't working with multiprocessing
+
+    network = planner.generate_ligand_network(components)
 
     # it should use the mapping ({0:2}) of the first mapper (BadMultiMapper)
     assert [e.componentA_to_componentB for e in network.edges] == len(network.edges) * [{0: 2}]

--- a/src/konnektor/tests/network_planners/generators/test_maximal_network_planner.py
+++ b/src/konnektor/tests/network_planners/generators/test_maximal_network_planner.py
@@ -78,7 +78,7 @@ def test_generate_maximal_network_missing_scorer(toluene_vs_others, n_process, w
         progress=with_progress,
         n_processes=n_process,
     )
-
-    network = planner.generate_ligand_network(components)
+    with pytest.warns():
+        network = planner.generate_ligand_network(components)
 
     assert [e.componentA_to_componentB for e in network.edges] == len(network.edges) * [{0: 0}]

--- a/src/konnektor/tests/network_planners/generators/test_maximal_network_planner.py
+++ b/src/konnektor/tests/network_planners/generators/test_maximal_network_planner.py
@@ -8,6 +8,7 @@ from konnektor.tests.network_planners.conf import (
     BadMapper,
     ErrorMapper,
     GenAtomMapper,
+    BadMultiMapper,
     SuperBadMapper,
     genScorer,
 )
@@ -65,15 +66,12 @@ def test_generate_maximal_network_mapper_error(toluene_vs_others, n_process, wit
 @pytest.mark.parametrize("n_process", [1, 2])
 @pytest.mark.parametrize("with_progress", [True, False])
 def test_generate_maximal_network_missing_scorer(toluene_vs_others, n_process, with_progress):
-    """If no scorer is provided, the first mapping of the last mapper should be used.
-    Note: this test isn't great because BadMapper only returns one mapping
-    """
-
+    """If no scorer is provided, the first mapping of the first mapper should be used."""
     toluene, others = toluene_vs_others
     components = others + [toluene]
 
     planner = MaximalNetworkGenerator(
-        mappers=[SuperBadMapper(), GenAtomMapper(), BadMapper()],
+        mappers=[BadMultiMapper(), SuperBadMapper(), BadMapper()],
         scorer=None,
         progress=with_progress,
         n_processes=n_process,
@@ -81,4 +79,5 @@ def test_generate_maximal_network_missing_scorer(toluene_vs_others, n_process, w
     with pytest.warns():
         network = planner.generate_ligand_network(components)
 
-    assert [e.componentA_to_componentB for e in network.edges] == len(network.edges) * [{0: 0}]
+    # it should use the mapping ({0:2}) of the first mapper (BadMultiMapper)
+    assert [e.componentA_to_componentB for e in network.edges] == len(network.edges) * [{0: 2}]

--- a/src/konnektor/tests/network_planners/generators/test_star_network_planner.py
+++ b/src/konnektor/tests/network_planners/generators/test_star_network_planner.py
@@ -7,8 +7,10 @@ from gufe import SmallMoleculeComponent
 import konnektor
 from konnektor.tests.network_planners.conf import (
     BadMapper,
+    BadMultiMapper,
     ErrorMapper,
     GenAtomMapper,
+    SuperBadMapper,
     genScorer,
     mol_from_smiles,
 )
@@ -58,15 +60,15 @@ def test_star_network_with_scorer(toluene_vs_others):
 def test_star_network_multiple_mappers_no_scorer(toluene_vs_others):
     toluene, others = toluene_vs_others
     # in this one, we should always take the bad mapper
-    mapper = BadMapper()
-    planner = konnektor.network_planners.RadialLigandNetworkPlanner(mappers=mapper, scorer=None)
+    mappers = [BadMultiMapper(), SuperBadMapper(), BadMapper()]
+    planner = konnektor.network_planners.RadialLigandNetworkPlanner(mappers=mappers, scorer=None)
 
-    with pytest.warns():
+    with pytest.warns(match="Only the first mapper provided will be used: <BadMulti"):
         network = planner.generate_ligand_network(components=others, central_component=toluene)
 
     assert len(network.edges) == len(others)
     for edge in network.edges:
-        assert edge.componentA_to_componentB == {0: 0}
+        assert edge.componentA_to_componentB == {0: 2}
 
 
 def test_star_network_failure(atom_mapping_basic_test_files):

--- a/src/konnektor/tests/network_planners/generators/test_star_network_planner.py
+++ b/src/konnektor/tests/network_planners/generators/test_star_network_planner.py
@@ -60,10 +60,11 @@ def test_star_network_multiple_mappers_no_scorer(toluene_vs_others):
     # in this one, we should always take the bad mapper
     mapper = BadMapper()
     planner = konnektor.network_planners.RadialLigandNetworkPlanner(mappers=mapper, scorer=None)
-    network = planner.generate_ligand_network(components=others, central_component=toluene)
+
+    with pytest.warns():
+        network = planner.generate_ligand_network(components=others, central_component=toluene)
 
     assert len(network.edges) == len(others)
-
     for edge in network.edges:
         assert edge.componentA_to_componentB == {0: 0}
 


### PR DESCRIPTION
 if no scorer is provided to the max network planners, the std. behavior is to take the first possible mapping and be done. It used to use the last possible mapping.

this change is a minor adaptation to the old openFE behavior.fixes unit tests.