### PR TITLE
pin rdkit to 2024.03.5

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -21,7 +21,7 @@ dependencies:
   - networkx
   - scikit-learn
   # Chem
-  - rdkit
+  - rdkit==2024.03.5
   # Vis
   - ipycytoscape
   # docs


### PR DESCRIPTION
This pins us to a version pre-`rdkit` bug. Their latest release has this fixed as well, but has some conflicts with our other dependencies that are not immediately resolvable. 