### PR TITLE
89 add tests to cover missing scorer behavior

### DIFF
--- a/src/konnektor/tests/network_planners/generators/test_heuristic_maximal_network_planner.py
+++ b/src/konnektor/tests/network_planners/generators/test_heuristic_maximal_network_planner.py
@@ -38,6 +38,7 @@ def test_generate_maximal_network(with_progress, n_process):
 @pytest.mark.parametrize("n_process", [1, 2])
 @pytest.mark.parametrize("with_progress", [True, False])
 def test_generate_maximal_network_missing_scorer(with_progress, n_process):
+    """If a scorer isn't provided, the first mapping from the last mapper should be used."""
     n_compounds = 4
     components, _, _ = build_random_dataset(n_compounds=n_compounds)
 

--- a/src/konnektor/tests/network_planners/generators/test_heuristic_maximal_network_planner.py
+++ b/src/konnektor/tests/network_planners/generators/test_heuristic_maximal_network_planner.py
@@ -6,12 +6,16 @@ import pytest
 from konnektor.network_analysis import get_is_connected
 from konnektor.network_planners import HeuristicMaximalNetworkGenerator
 from konnektor.utils.toy_data import build_random_dataset
-
+from konnektor.tests.network_planners.conf import (
+    genScorer,
+    GenAtomMapper,
+    BadMapper,
+    SuperBadMapper
+)
 
 @pytest.mark.parametrize("n_process", [1, 2])
 @pytest.mark.parametrize("with_progress", [True, False])
-@pytest.mark.parametrize("with_scorer", [True, False])
-def test_generate_maximal_network(with_progress, with_scorer, n_process):
+def test_generate_maximal_network(with_progress, n_process):
     n_compounds = 20
     components, genMapper, genScorer = build_random_dataset(n_compounds=n_compounds)
 
@@ -30,3 +34,28 @@ def test_generate_maximal_network(with_progress, with_scorer, n_process):
     assert len(network.edges) <= edge_count
     assert len(network.edges) > n_compounds
     assert get_is_connected(network)
+
+@pytest.mark.parametrize("n_process", [1, 2])
+@pytest.mark.parametrize("with_progress", [True, False])
+def test_generate_maximal_network_missing_scorer(with_progress, n_process):
+    n_compounds = 4
+    components, _, _ = build_random_dataset(n_compounds=n_compounds)
+
+    planner = HeuristicMaximalNetworkGenerator(
+        mappers= [SuperBadMapper(), GenAtomMapper(), BadMapper()],
+        scorer=None,
+        n_samples=3,
+        progress=with_progress,
+        n_processes=n_process,
+    )
+    network = planner.generate_ligand_network(components)
+
+    assert len(network.nodes) == n_compounds
+
+    edge_count = n_compounds * 3
+    assert len(network.edges) <= edge_count
+    assert len(network.edges) > n_compounds
+    assert get_is_connected(network)
+
+    assert [e.componentA_to_componentB for e in network.edges] == len(network.edges)*[{0:0}]
+

--- a/src/konnektor/tests/network_planners/generators/test_heuristic_maximal_network_planner.py
+++ b/src/konnektor/tests/network_planners/generators/test_heuristic_maximal_network_planner.py
@@ -38,7 +38,9 @@ def test_generate_maximal_network(with_progress, n_process):
 @pytest.mark.parametrize("n_process", [1, 2])
 @pytest.mark.parametrize("with_progress", [True, False])
 def test_generate_maximal_network_missing_scorer(with_progress, n_process):
-    """If a scorer isn't provided, the first mapping from the last mapper should be used."""
+    """If no scorer is provided, the first mapping of the last mapper should be used.
+       Note: this test isn't great because BadMapper only returns one mapping
+    """
     n_compounds = 4
     components, _, _ = build_random_dataset(n_compounds=n_compounds)
 

--- a/src/konnektor/tests/network_planners/generators/test_maximal_network_planner.py
+++ b/src/konnektor/tests/network_planners/generators/test_maximal_network_planner.py
@@ -10,6 +10,33 @@ from konnektor.tests.network_planners.conf import (
     genScorer,
     GenAtomMapper,
 )
+from gufe import LigandAtomMapping, AtomMapper, AtomMapping
+from konnektor.utils.toy_data import build_random_dataset
+
+
+class CounterTestMapper(AtomMapper):
+    def __init__(self):
+        """
+        Build a generic Mapper, that only has use for dummy mappings.
+        Generates mappings that increment by 1 for testing order-dependent behavior.
+        """
+        pass
+
+    def suggest_mappings(self, molA, molB) -> AtomMapping:
+        yield LigandAtomMapping(molA, molB, {0:1})
+
+    @classmethod
+    def _defaults(cls):
+        return super()._defaults()
+
+    @classmethod
+    def _from_dict(cls, d):
+        s = cls()
+        [setattr(s, k, v) for k, v in d.items()]
+        return s
+
+    def _to_dict(self):
+        return vars(self)
 
 
 @pytest.mark.parametrize("n_process", [1, 2])
@@ -41,3 +68,18 @@ def test_generate_maximal_network(
     else:
         for edge in network.edges:
             assert "score" not in edge.annotations
+
+def test_generate_maximal_network_missing_scorer():
+    """If no scorer is provided, the last mapper tried should be used."""
+
+    components, empty_mapper, _ = build_random_dataset(n_compounds=2)
+    counter_mapper = CounterTestMapper()
+    planner = MaximalNetworkGenerator(
+        mappers= [empty_mapper, counter_mapper],
+        scorer=None,
+        progress=False,
+        n_processes=1,
+    )
+    network = planner.generate_ligand_network(components)
+    assert [e for e in network.edges][-1].componentA_to_componentB == {0:1}
+    [(e.componentA.name, e.componentB.name) for e in network.edges]


### PR DESCRIPTION
This gets the job done to address coverage concerns in https://github.com/OpenFreeEnergy/konnektor/pull/84.

I'd also like to look into the bare `except` error catching. We should be more specific about what errors are okay, and which we want to let be thrown. 