### PR TITLE
Fix recursion error

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -27,6 +27,7 @@ dependencies:
   # docs
   - myst-parser
   - pydata-sphinx-theme
+  - tqdm
 
   - pip:
     - dill

--- a/src/konnektor/network_tools/clustering/auxilliary_featurizer.py
+++ b/src/konnektor/network_tools/clustering/auxilliary_featurizer.py
@@ -19,16 +19,7 @@ class ChargeTransformer(FpsTransformer):
 
         """
         super().__init__(parallel=parallel)
-        self.nBits = 1
-
-    @property
-    def fpSize(self):
-        return self.nBits
-
-    # Scikit-Learn expects to be able to set fpSize directly on object via .set_params(), so this updates nBits used by the abstract class
-    @fpSize.setter
-    def fpSize(self, fpSize):
-        self.nBits = fpSize
+        self.fpSize = 1
 
     def _mol2fp(self, mol):
         pass


### PR DESCRIPTION
resolves https://github.com/OpenFreeEnergy/konnektor/issues/102

the `nBits` attribute has been deprecated in scikit-mol, which caused a recursion error in this patch. Switching to directly assigning `fpSize` seems to resolve this.