### PR TITLE
Fix colab link in docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,7 +14,7 @@ Ontop of the described ligand network planners, Konnektor gives access to tools,
 Analysis of networks, like calculating graph scores, getting the connectivities of network nodes or calculating the network robustness are available too.
 Last we want to bring to your attention our Network visualization tools and the provided interactive network visualization widget for IPython like in Jupyter-Lab/Notebooks.
 
-Try our interactive demo: ![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)
+Try our interactive demo: |Colab|
 
 .. toctree::
    :maxdepth: 2
@@ -24,3 +24,6 @@ Try our interactive demo: ![Open In Colab](https://colab.research.google.com/ass
    tutorial
    guide
    api
+
+.. |Colab| image:: https://colab.research.google.com/assets/colab-badge.svg
+   :target: https://colab.research.google.com/github/OpenFreeEnergy/konnektor/blob/main/examples/konnektor_example.ipynb#scrollTo=GU32PaMkzD7x


### PR DESCRIPTION
Colab link was broken (used markdown instead of rst syntax), this fixes it.

## Tips
* Comment "pre-commit.ci autofix" to have pre-commit.ci auto-format your PR.
  Since this will create a commit, it is best to make this comment when you are finished with your work.

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.


## Reviewer Checklist
- [ ] news entry has been added if necessary
- [ ] pre-commit auto fix has been run
- [ ] any API breaks have been documented
