### PR TITLE
Fix disconnected network handling

### DIFF
--- a/src/konnektor/network_planners/generators/explicit_network_generator.py
+++ b/src/konnektor/network_planners/generators/explicit_network_generator.py
@@ -42,8 +42,7 @@ class ExplicitNetworkGenerator(NetworkGenerator):
         )
 
     def generate_ligand_network(
-        self,
-        edges: Iterable[tuple[Component, Component]],
+        self, edges: Iterable[tuple[Component, Component]], nodes: Iterable[Component] | None = None
     ) -> LigandNetwork:
         """
         Create a network with pre-defined edges.
@@ -61,7 +60,6 @@ class ExplicitNetworkGenerator(NetworkGenerator):
         LigandNetwork
             the provided network.
         """
-        nodes = list(set([n for e in edges for n in e]))
 
         mappings = _parallel_map_scoring(
             possible_edges=edges,
@@ -87,14 +85,13 @@ class ExplicitNetworkGenerator(NetworkGenerator):
 
         Parameters
         ----------
-        components : list of Components
-          the small molecules to place into the network
-        mapper: AtomMapper
-          the atom mapper to use to construct edges
-        indices : list of tuples of indices
-          the edges to form where the values refer to names of the small molecules,
-          eg `[(3, 4), ...]` will create an edge between the 3rd and 4th molecules
-          remembering that Python uses 0-based indexing
+        components : list[Component]
+            ``SmallMoleculeComponent``/s to place into the network.
+
+        indices : list[tuple[int, int]]
+            Edges to form between the components, represented as tuples of indices of the list of components.
+            e.g. `[(3, 4), ...]` will create an edge between the 3rd and 4th molecules
+            (remember that Python uses 0-based indexing)
 
         Returns
         -------
@@ -103,9 +100,10 @@ class ExplicitNetworkGenerator(NetworkGenerator):
         Raises
         ------
         IndexError
-          if an invalid ligand index is requested
+            Throws an error if the ``indices`` specified are not present in ``components``.
         """
         edges = []
+
         for i, j in indices:
             try:
                 edges.append((components[i], components[j]))
@@ -114,7 +112,7 @@ class ExplicitNetworkGenerator(NetworkGenerator):
                     f"Invalid ligand id, requested {i} {j} with {len(components)} available"
                 )
 
-        return self.generate_ligand_network(edges=edges)
+        return self.generate_ligand_network(edges=edges, nodes=components)
 
     def generate_network_from_names(
         self,

--- a/src/konnektor/network_planners/generators/explicit_network_generator.py
+++ b/src/konnektor/network_planners/generators/explicit_network_generator.py
@@ -86,7 +86,7 @@ class ExplicitNetworkGenerator(NetworkGenerator):
         Parameters
         ----------
         components : list[Component]
-            ``SmallMoleculeComponent``/s to place into the network.
+            ``Component``/s to place into the network.
 
         indices : list[tuple[int, int]]
             Edges to form between the components, represented as tuples of indices of the list of components.
@@ -124,8 +124,8 @@ class ExplicitNetworkGenerator(NetworkGenerator):
 
         Parameters
         ----------
-        components : list of Components
-          the small molecules to place into the network
+        components : list[Component]
+                ``Component``/s to place into the network.
         mapper: AtomMapper
           the atom mapper to use to construct edges
         names : list of tuples of names
@@ -140,10 +140,9 @@ class ExplicitNetworkGenerator(NetworkGenerator):
         Raises
         ------
         KeyError
-          if an invalid name is requested
+          If a name in ``names`` is not present in ``components`.
         ValueError
-          if multiple molecules have the same name (this would otherwise be
-          problematic)
+          If multiple molecules have the same name (molecule names must be unique)
         """
         nm2comp = {c.name: c for c in components}
 
@@ -161,4 +160,4 @@ class ExplicitNetworkGenerator(NetworkGenerator):
                 available = [ligand.name for ligand in components]
                 raise KeyError(f"Invalid name(s) requested {badnames}.  Available: {available}")
 
-        return self.generate_ligand_network(edges=edges)
+        return self.generate_ligand_network(edges=edges, nodes=components)

--- a/src/konnektor/tests/network_planners/generators/test_explicit_network_planner.py
+++ b/src/konnektor/tests/network_planners/generators/test_explicit_network_planner.py
@@ -3,6 +3,7 @@
 
 import itertools
 
+import pytest
 from gufe import LigandNetwork
 
 from konnektor.network_analysis import get_is_connected
@@ -28,22 +29,28 @@ def test_explicit_network_planner():
     assert get_is_connected(ligand_network)
 
 
-def test_explicit_network_planner_with_indices():
+def test_explicit_network_planner_from_indices():
+    pass
+
+
+def test_explicit_network_planner_from_indices_disconnected():
     n_compounds = 20
     components, genMapper, genScorer = build_random_dataset(n_compounds=n_compounds)
     indices = [(1, 2), (2, 3), (3, 4), (2, 5), (2, 6)]
-    unique_indices = set([i for e in indices for i in e])
     planner = ExplicitNetworkGenerator(genMapper, genScorer, n_processes=1)
 
-    ligand_network = planner.generate_network_from_indices(components=components, indices=indices)
+    with pytest.warns(match="Generated network is not fully connected"):
+        ligand_network = planner.generate_network_from_indices(
+            components=components, indices=indices
+        )
 
     assert isinstance(ligand_network, LigandNetwork)
-    assert len(ligand_network.nodes) == len(unique_indices)
+    assert len(ligand_network.nodes) == n_compounds
     assert len(ligand_network.edges) == len(indices)
-    assert get_is_connected(ligand_network)
+    assert not get_is_connected(ligand_network)
 
 
-def test_explicit_network_planner_with_names():
+def test_explicit_network_planner_from_names():
     n_compounds = 20
     components, genMapper, genScorer = build_random_dataset(n_compounds=n_compounds)
     print(components[0].name)
@@ -58,3 +65,7 @@ def test_explicit_network_planner_with_names():
     assert len(ligand_network.nodes) == len(unique_names)
     assert len(ligand_network.edges) == len(names)
     assert get_is_connected(ligand_network)
+
+
+def test_explicit_network_planner_from_names_disconnected():
+    pass

--- a/src/konnektor/tests/network_planners/generators/test_explicit_network_planner.py
+++ b/src/konnektor/tests/network_planners/generators/test_explicit_network_planner.py
@@ -51,21 +51,19 @@ def test_explicit_network_planner_from_indices_disconnected():
 
 
 def test_explicit_network_planner_from_names():
+    pass
+
+
+def test_explicit_network_planner_from_names_disconnected():
     n_compounds = 20
     components, genMapper, genScorer = build_random_dataset(n_compounds=n_compounds)
-    print(components[0].name)
     names = [("0", "1"), ("1", "2"), ("2", "3"), ("1", "5"), ("1", "6")]
-    unique_names = set([i for e in names for i in e])
 
     planner = ExplicitNetworkGenerator(genMapper, genScorer, n_processes=1)
 
     ligand_network = planner.generate_network_from_names(components=components, names=names)
 
     assert isinstance(ligand_network, LigandNetwork)
-    assert len(ligand_network.nodes) == len(unique_names)
+    assert len(ligand_network.nodes) == n_compounds
     assert len(ligand_network.edges) == len(names)
-    assert get_is_connected(ligand_network)
-
-
-def test_explicit_network_planner_from_names_disconnected():
-    pass
+    assert not get_is_connected(ligand_network)

--- a/src/konnektor/tests/network_planners/generators/test_explicit_network_planner.py
+++ b/src/konnektor/tests/network_planners/generators/test_explicit_network_planner.py
@@ -61,7 +61,8 @@ def test_explicit_network_planner_from_names_disconnected():
 
     planner = ExplicitNetworkGenerator(genMapper, genScorer, n_processes=1)
 
-    ligand_network = planner.generate_network_from_names(components=components, names=names)
+    with pytest.warns(match="Generated network is not fully connected"):
+        ligand_network = planner.generate_network_from_names(components=components, names=names)
 
     assert isinstance(ligand_network, LigandNetwork)
     assert len(ligand_network.nodes) == n_compounds


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

this is part of [konnektor integration](https://github.com/OpenFreeEnergy/openfe/pull/927), and making openfe and konnektor handling match.
 
resolves https://github.com/OpenFreeEnergy/openfe/issues/1020
 
This PR makes it so that `generate_network_from_names()` and `generate_network_from_indices()` match the behavior current in openfe. i.e. a network is created containing *all* the components passed in as nodes, even if that means the resulting network is disconnected. If the resulting network is disconnected, a warning is raised, but it is still considered valid.

I know that Ben was hesitant about allowing disconnected networks, but I think that for these explicit network generators, it makes sense to give the user as much control as we can. If we decide to enforce connected networks in other parts of konnektor, that can be done in more specific implementations.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

## PR Author Checklist
- [ ] add news item if changes are user-facing
- [ ] run `pre-commit.ci autofix` when the PR is ready for review

## Tips
* Comment "pre-commit.ci autofix" to have pre-commit.ci auto-format your PR.
  Since this will create a commit, it is best to make this comment when you are finished with your work.

## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.


## Reviewer Checklist
- [ ] news entry has been added if necessary
- [ ] pre-commit auto fix has been run
- [ ] any API breaks have been documented
