### PR TITLE
max network - fix scoring and add tests

### DIFF
--- a/src/konnektor/network_planners/_map_scoring.py
+++ b/src/konnektor/network_planners/_map_scoring.py
@@ -35,7 +35,7 @@ def _determine_best_mapping(
     AtomMapping
         The best mapping found for the component pair.
     """
-    best_score = -1.0
+    best_score = 0.0
     best_mapping = None
     molA = component_pair[0]
     molB = component_pair[1]
@@ -56,7 +56,7 @@ def _determine_best_mapping(
                 # TODO: where should we enforce that this score is in [0,1]?
                 tmp_best_mapping = max(tmp_mappings, key=lambda m: m.annotations["score"])
                 # TODO: we still need a more explicit tie-breaking scheme
-                if tmp_best_mapping.annotations["score"] > best_score:
+                if tmp_best_mapping.annotations["score"] > best_score or best_mapping is None:
                     best_score = tmp_best_mapping.annotations["score"]
                     best_mapping = tmp_best_mapping
         else:

--- a/src/konnektor/network_planners/_map_scoring.py
+++ b/src/konnektor/network_planners/_map_scoring.py
@@ -27,8 +27,8 @@ def _determine_best_mapping(
         The two molecules for which the best mapping will be determined.
     mappers : AtomMapper | list[AtomMapper]
         The mapper(s) to use to generate possible mappings between the molecules in the ``component_pair``.
-    scorer : Callable
-        _description_
+    scorer : Optional[Callable]
+        The mapping scorer to use, in the form of a ``Callable`` that takes in an ``AtomMapping`` and returns a float in [0,1].
 
     Returns
     -------

--- a/src/konnektor/network_planners/_map_scoring.py
+++ b/src/konnektor/network_planners/_map_scoring.py
@@ -35,7 +35,7 @@ def _determine_best_mapping(
     AtomMapping
         The best mapping found for the component pair.
     """
-    best_score = 0.0
+    best_score = -1.0
     best_mapping = None
     molA = component_pair[0]
     molB = component_pair[1]
@@ -53,9 +53,10 @@ def _determine_best_mapping(
             ]
 
             if len(tmp_mappings) > 0:
+                # TODO: where should we enforce that this score is in [0,1]?
                 tmp_best_mapping = max(tmp_mappings, key=lambda m: m.annotations["score"])
-                # TODO: we still need a tie-breaking scheme, then we can get rid of 'best_mapping is None'
-                if tmp_best_mapping.annotations["score"] > best_score or best_mapping is None:
+                # TODO: we still need a more explicit tie-breaking scheme
+                if tmp_best_mapping.annotations["score"] > best_score:
                     best_score = tmp_best_mapping.annotations["score"]
                     best_mapping = tmp_best_mapping
         else:

--- a/src/konnektor/network_planners/_map_scoring.py
+++ b/src/konnektor/network_planners/_map_scoring.py
@@ -54,8 +54,8 @@ def _determine_best_mapping(
 
             if len(tmp_mappings) > 0:
                 tmp_best_mapping = max(tmp_mappings, key=lambda m: m.annotations["score"])
-
-                if tmp_best_mapping.annotations["score"] > best_score:
+                # TODO: we still need a tie-breaking scheme, then we can get rid of 'best_mapping is None'
+                if tmp_best_mapping.annotations["score"] > best_score or best_mapping is None:
                     best_score = tmp_best_mapping.annotations["score"]
                     best_mapping = tmp_best_mapping
         else:

--- a/src/konnektor/network_planners/generators/maximal_network_generator.py
+++ b/src/konnektor/network_planners/generators/maximal_network_generator.py
@@ -19,7 +19,7 @@ class MaximalNetworkGenerator(NetworkGenerator):
         n_processes: int = 1,
     ):
         """
-        The `MaximalNetworkGenerator` attempts to build a fully connected graph (every node connected to every other node) for given set of `Component`/s.
+        The ``MaximalNetworkGenerator`` attempts to build a fully connected graph (every node connected to every other node) for given set of `Component`/s.
 
         The edges of the graph are ``Transformation`` s, which contain `AtomMapping` s of pairwise `Component`/s.
         If not all mappings can be created, it will ignore the mapping failure and return a nearly fully connected graph.

--- a/src/konnektor/network_planners/generators/maximal_network_generator.py
+++ b/src/konnektor/network_planners/generators/maximal_network_generator.py
@@ -14,14 +14,14 @@ class MaximalNetworkGenerator(NetworkGenerator):
     def __init__(
         self,
         mappers: AtomMapper | list[AtomMapper],
-        scorer: Callable,
+        scorer: Callable | None,
         progress: bool = False,
         n_processes: int = 1,
     ):
         """
         The ``MaximalNetworkGenerator`` attempts to build a fully connected graph (every node connected to every other node) for given set of `Component`/s.
 
-        The edges of the graph are ``Transformation`` s, which contain `AtomMapping` s of pairwise `Component`/s.
+        The edges of the graph are ``Transformation`` s, which contain ``AtomMapping`` s of pairwise ``Component``/s.
         If not all mappings can be created, it will ignore the mapping failure and return a nearly fully connected graph.
 
         If multiple ``AtomMapper``/s are provided, but no scorer, the *first valid* ``AtomMapper`` provided will be used.
@@ -38,7 +38,7 @@ class MaximalNetworkGenerator(NetworkGenerator):
         ----------
         mappers: Union[AtomMapper, list[AtomMapper]]
             ``AtomMapper`` to use to define the relationship between two ligands.
-        scorer: Callable
+        scorer: Callable, optional
             Scoring function that takes in an atom mapping and returns a score in [0,1].
         progress: bool, optional
             If True, a progress bar will be displayed. (default: False)

--- a/src/konnektor/network_planners/generators/maximal_network_generator.py
+++ b/src/konnektor/network_planners/generators/maximal_network_generator.py
@@ -19,10 +19,12 @@ class MaximalNetworkGenerator(NetworkGenerator):
         n_processes: int = 1,
     ):
         """
-        The `MaximalNetworkGenerator` attempts to build a fully connected graph for given set of `Component`/s.
-        It assumes each `Component` can be connected to every other `Component`.
-        The `Transformation` s of this graph are realized as `AtomMapping` s of pairwise `Component`/s.
+        The `MaximalNetworkGenerator` attempts to build a fully connected graph (every node connected to every other node) for given set of `Component`/s.
+
+        The edges of the graph are ``Transformation`` s, which contain `AtomMapping` s of pairwise `Component`/s.
         If not all mappings can be created, it will ignore the mapping failure and return a nearly fully connected graph.
+
+        If multiple ``AtomMapper``/s are provided, but no scorer, the *first valid* ``AtomMapper`` provided will be used.
 
         ... note::
         This approach is not recommended for Free Energy calculations in application cases, as it is very computationally expensive.

--- a/src/konnektor/network_planners/generators/maximal_network_generator.py
+++ b/src/konnektor/network_planners/generators/maximal_network_generator.py
@@ -2,7 +2,7 @@
 # For details, see https://github.com/OpenFreeEnergy/konnektor
 
 import itertools
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 
 from gufe import AtomMapper, Component, LigandNetwork
 
@@ -14,14 +14,14 @@ class MaximalNetworkGenerator(NetworkGenerator):
     def __init__(
         self,
         mappers: AtomMapper | list[AtomMapper],
-        scorer,
+        scorer: Callable,
         progress: bool = False,
         n_processes: int = 1,
     ):
         """
-        The `MaximalNetworkGenerator` builds a fully connected graph for given set of `Component` s.
+        The `MaximalNetworkGenerator` attempts to build a fully connected graph for given set of `Component`/s.
         It assumes each `Component` can be connected to every other `Component`.
-        The `Transformation` s of this graph are realized as `AtomMapping` s of pairwise `Component` s.
+        The `Transformation` s of this graph are realized as `AtomMapping` s of pairwise `Component`/s.
         If not all mappings can be created, it will ignore the mapping failure and return a nearly fully connected graph.
 
         ... note::
@@ -29,20 +29,19 @@ class MaximalNetworkGenerator(NetworkGenerator):
         However, this approach is very important, as all other approaches use the Maximal Network as an initial solution,
         then remove edges to achieve the desired design.
 
-        This class is recommended as an `initial_edge_lister` for other approaches.
-        The `MaximalNetworkGenerator` is parallelized and the number of CPUs can be given with `n_processes`.
-        All other approaches in Konnektor benefit from this parallelization and you can use this parallelization with `n_processes` key word during class construction.
+        This class is recommended as an ``initial_edge_lister`` for other network generators.
+        The ``MaximalNetworkGenerator`` is parallelized and the number of CPUs can be chosen with the ``n_processes`` argument.
 
         Parameters
         ----------
         mappers: Union[AtomMapper, list[AtomMapper]]
-            the atom mapper is required, to define the connection between two ligands.
-        scorer: AtomMappingScorer
-            scoring function evaluating an atom mapping, and giving a score between [0,1].
+            ``AtomMapper`` to use to define the relationship between two ligands.
+        scorer: Callable
+            Scoring function that takes in an atom mapping and returns a score in [0,1].
         progress: bool, optional
-            if true a progress bar will be displayed. (default: False)
+            If True, a progress bar will be displayed. (default: False)
         n_processes: int
-            number of processes that can be used for the network generation. (default: 1)
+            Number of processes to use for network generation. (default: 1)
         """
 
         super().__init__(
@@ -65,17 +64,17 @@ class MaximalNetworkGenerator(NetworkGenerator):
         generators (which then optimize based on the scores) or to debug atom
         mappers (to see which mappings the mapper fails to generate).
 
-
         Parameters
         ----------
         components : Iterable[SmallMoleculeComponent]
-          the ligands to include in the LigandNetwork
+            ``SmallMoleculeComponent``/s to include as nodes in the ``LigandNetwork``.
 
         Returns
         -------
         LigandNetwork
-            a ligand network containing all possible mappings, ideally a fully connected graph.
+            ``LigandNetwork`` containing all possible mappings, ideally a fully connected graph.
         """
+
         components = list(components)
         total = len(components) * (len(components) - 1) // 2
 
@@ -100,5 +99,6 @@ class MaximalNetworkGenerator(NetworkGenerator):
         if len(mappings) == 0:
             raise RuntimeError("Could not generate any mapping!")
 
+        # TODO: raise an error? warning? if resulting network is disconnected
         network = LigandNetwork(edges=mappings, nodes=components)
         return network

--- a/src/konnektor/tests/network_planners/conf.py
+++ b/src/konnektor/tests/network_planners/conf.py
@@ -92,8 +92,13 @@ class ErrorMapper(DummyAtomMapper):
         raise ValueError("No mapping found for")
 
 
-def genScorer(mapping):
+def genScorer(mapping) -> float:
     """A general scorer for testing where the score is proportional to the length of the mapping.
     (i.e. a longer mapping gets a higher, and therefore better, score)
     """
     return 1 - (1.0 / len(mapping.componentA_to_componentB))
+
+
+def zeroScorer(mapping):
+    """A test scorer that always returns zero."""
+    return 0

--- a/src/konnektor/tests/network_planners/generators/test_maximal_network_planner.py
+++ b/src/konnektor/tests/network_planners/generators/test_maximal_network_planner.py
@@ -46,8 +46,9 @@ def test_generate_maximal_network(toluene_vs_others, with_progress, with_scorer,
 @pytest.mark.parametrize("n_process", [1, 2])
 @pytest.mark.parametrize("with_progress", [True, False])
 def test_generate_maximal_network_mapper_error(toluene_vs_others, n_process, with_progress):
-    """ """
-
+    """If no scorer, use the first valid mapper.
+    # TODO: do we want this behavior, or should we enforce using the first mapper, then error out?
+    """
     toluene, others = toluene_vs_others
     components = others + [toluene]
 
@@ -60,6 +61,7 @@ def test_generate_maximal_network_mapper_error(toluene_vs_others, n_process, wit
 
     network = planner.generate_ligand_network(components)
 
+    # make sure the BadMapper was used ({0:0})
     assert [e.componentA_to_componentB for e in network.edges] == len(network.edges) * [{0: 0}]
 
 

--- a/src/konnektor/tests/network_planners/generators/test_maximal_network_planner.py
+++ b/src/konnektor/tests/network_planners/generators/test_maximal_network_planner.py
@@ -11,6 +11,7 @@ from konnektor.tests.network_planners.conf import (
     GenAtomMapper,
     SuperBadMapper,
     genScorer,
+    zeroScorer,
 )
 
 
@@ -85,12 +86,37 @@ def test_generate_maximal_network_no_scorer(toluene_vs_others, n_process, with_p
     # it should use the mapping ({0:2}) of the first mapper (BadMultiMapper)
     assert [e.componentA_to_componentB for e in network.edges] == len(network.edges) * [{0: 2}]
 
+
 @pytest.mark.parametrize("n_process", [1, 2])
 def test_generate_maximal_network_no_edges(toluene_vs_others, n_process):
     toluene, others = toluene_vs_others
     components = others + [toluene]
 
-    planner = MaximalNetworkGenerator(mappers=ErrorMapper(), scorer=genScorer, progress=False, n_processes=n_process)
+    planner = MaximalNetworkGenerator(
+        mappers=ErrorMapper(), scorer=genScorer, progress=False, n_processes=n_process
+    )
 
     with pytest.raises(RuntimeError, match="Could not generate any mapping"):
         planner.generate_ligand_network(components=components)
+
+
+@pytest.mark.parametrize("n_process", [1, 2])
+def test_generate_maximal_network_zero_scorer(toluene_vs_others, n_process):
+    """If all the scores are 0.0, we still want a network returned.
+    TODO: Deterministic tie-breaking scheme TBD.
+    """
+    toluene, others = toluene_vs_others
+    components = others + [toluene]
+
+    planner = MaximalNetworkGenerator(
+        mappers=[BadMultiMapper(), SuperBadMapper(), BadMapper()],
+        scorer=zeroScorer,
+        progress=False,
+        n_processes=n_process,
+    )
+
+    network = planner.generate_ligand_network(components)
+
+    # it should use the mapping ({0:2}) of the first mapper (BadMultiMapper) in the case of a tie (for now)
+    assert [e.componentA_to_componentB for e in network.edges] == len(network.edges) * [{0: 2}]
+    assert [e.annotations["score"] for e in network.edges] == len(network.edges) * [0]

--- a/src/konnektor/tests/network_planners/generators/test_maximal_network_planner.py
+++ b/src/konnektor/tests/network_planners/generators/test_maximal_network_planner.py
@@ -60,7 +60,6 @@ def test_generate_maximal_network_mapper_error(toluene_vs_others, n_process, wit
     )
 
     network = planner.generate_ligand_network(components)
-
     # make sure the BadMapper was used ({0:0})
     assert [e.componentA_to_componentB for e in network.edges] == len(network.edges) * [{0: 0}]
 
@@ -85,3 +84,13 @@ def test_generate_maximal_network_no_scorer(toluene_vs_others, n_process, with_p
 
     # it should use the mapping ({0:2}) of the first mapper (BadMultiMapper)
     assert [e.componentA_to_componentB for e in network.edges] == len(network.edges) * [{0: 2}]
+
+@pytest.mark.parametrize("n_process", [1, 2])
+def test_generate_maximal_network_no_edges(toluene_vs_others, n_process):
+    toluene, others = toluene_vs_others
+    components = others + [toluene]
+
+    planner = MaximalNetworkGenerator(mappers=ErrorMapper(), scorer=genScorer, progress=False, n_processes=n_process)
+
+    with pytest.raises(RuntimeError, match="Could not generate any mapping"):
+        planner.generate_ligand_network(components=components)

--- a/src/konnektor/tests/network_planners/generators/test_rmst_network_planner.py
+++ b/src/konnektor/tests/network_planners/generators/test_rmst_network_planner.py
@@ -66,7 +66,7 @@ def test_rminimal_spanning_network_connectedness(rminimal_spanning_network_redun
     assert nx.is_connected(nx.MultiGraph(minimal_spanning_network.graph))
 
 
-def test_minimal_rmst_network_noedger(toluene_vs_others):
+def test_minimal_rmst_network_no_edges(toluene_vs_others):
     toluene, others = toluene_vs_others
     nimrod = gufe.SmallMoleculeComponent(mol_from_smiles("N"))
 

--- a/src/konnektor/tests/network_planners/generators/test_rmst_network_planner.py
+++ b/src/konnektor/tests/network_planners/generators/test_rmst_network_planner.py
@@ -70,8 +70,7 @@ def test_minimal_rmst_network_no_edges(toluene_vs_others):
     toluene, others = toluene_vs_others
     nimrod = gufe.SmallMoleculeComponent(mol_from_smiles("N"))
 
-    mapper = ErrorMapper()
+    planner = RedundantMinimalSpanningTreeNetworkGenerator(mappers=ErrorMapper(), scorer=genScorer)
 
     with pytest.raises(RuntimeError, match="Could not generate any mapping"):
-        planner = RedundantMinimalSpanningTreeNetworkGenerator(mappers=mapper, scorer=genScorer)
         planner.generate_ligand_network(components=others + [toluene, nimrod])


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
I'm working on a downstream PR that will enforce a single mapper if no scorer is provided (as discussed [here](https://github.com/OpenFreeEnergy/openfe/issues/1019#issuecomment-2698753385)), but this is pre-work and clean up that is independent of that behavior change.


<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

## PR Author Checklist
- [x] ~~add news item if changes are user-facing~~ (not user-facing)
- [x] run `pre-commit.ci autofix` when the PR is ready for review

## Tips
* Comment "pre-commit.ci autofix" to have pre-commit.ci auto-format your PR.
  Since this will create a commit, it is best to make this comment when you are finished with your work.

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.


## Reviewer Checklist
- [ ] news entry has been added if necessary
- [ ] pre-commit auto fix has been run
- [ ] any API breaks have been documented
