### PR TITLE
fix scorer warning

### DIFF
--- a/src/konnektor/network_planners/_map_scoring.py
+++ b/src/konnektor/network_planners/_map_scoring.py
@@ -12,7 +12,7 @@ from tqdm.auto import tqdm
 
 def _determine_best_mapping(
     component_pair: tuple[SmallMoleculeComponent],
-    mappers: AtomMapper | list[AtomMapper],
+    mappers: list[AtomMapper],
     scorer: Callable | None,
 ) -> AtomMapping:
     """
@@ -61,12 +61,14 @@ def _determine_best_mapping(
                     best_mapping = tmp_best_mapping
         else:
             try:
-                warnings.warn(
-                    f"Multiple mappers were provided, but no scorer. Only the first mapper provided will be used: {mapper}"
-                )
                 best_mapping = next(mapping_generator)
+                if len(mappers) > 1:
+                    warnings.warn(
+                        "Multiple mappers were provided, but no scorer."
+                        f"Only the first valid mapper provided will be used: {mapper}"
+                    )
                 break
-            except:  # TODO: I don't think this except is needed
+            except:  # TODO: fix this bare except, or remove it (first mapper vs. first valid mapper)
                 continue
 
     return best_mapping


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
The warning was getting raise for all instances where there is no scorer - we only want a warning if it's a scorer + multiple mappers.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

## PR Author Checklist
- [ ] add news item if changes are user-facing
- [ ] run `pre-commit.ci autofix` when the PR is ready for review

## Tips
* Comment "pre-commit.ci autofix" to have pre-commit.ci auto-format your PR.
  Since this will create a commit, it is best to make this comment when you are finished with your work.

## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.


## Reviewer Checklist
- [ ] news entry has been added if necessary
- [ ] pre-commit auto fix has been run
- [ ] any API breaks have been documented
