### PR TITLE
fixing behavior where radial network would create a self-edge

### DIFF
--- a/news/fix_self_edge.rst
+++ b/news/fix_self_edge.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* For radial (star) network generation, if ``central_component`` is already in the list passed to ``components``, a self-edge will no longer be created, and a warning is raised.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/konnektor/network_planners/generators/star_network_generator.py
+++ b/src/konnektor/network_planners/generators/star_network_generator.py
@@ -2,6 +2,7 @@
 # For details, see https://github.com/OpenFreeEnergy/konnektor
 
 import functools
+import warnings
 from collections.abc import Iterable
 
 from gufe import AtomMapper, Component, LigandNetwork
@@ -115,6 +116,14 @@ class StarNetworkGenerator(NetworkGenerator):
 
             selected_mappings = []
             for component in progress(components):
+                if component == central_component:
+                    wmsg = (
+                        f"The central_component '{central_component.name}' was also found in "
+                        "the list of components to arrange around the central_component, "
+                        f"this will be ignored (no self-edge will be created for {central_component.name})."
+                    )
+                    warnings.warn(wmsg)
+                    continue
                 best_mapping = _determine_best_mapping(
                     component_pair=(central_component, component),
                     mappers=self.mappers,


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

Caught by [this test](https://github.com/OpenFreeEnergy/openfe/blob/9533f95d462b52fc9ea1f86782d0451a756cc307/openfe/tests/setup/test_network_planning.py#L156) during konnektor integration. If the central component is present in "components" , we should NOT be creating a self-edge.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

## PR Author Checklist
- [x] add news item if changes are user-facing
- [x] run `pre-commit.ci autofix` when the PR is ready for review

## Tips
* Comment "pre-commit.ci autofix" to have pre-commit.ci auto-format your PR.
  Since this will create a commit, it is best to make this comment when you are finished with your work.

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.


## Reviewer Checklist
- [ ] news entry has been added if necessary
- [ ] pre-commit auto fix has been run
- [ ] any API breaks have been documented
