### PR TITLE
refactor to make edge ordering match openfe

### DIFF
--- a/src/konnektor/network_planners/_networkx_implementations/mst_network_algorithm.py
+++ b/src/konnektor/network_planners/_networkx_implementations/mst_network_algorithm.py
@@ -14,7 +14,7 @@ class MstNetworkAlgorithm(_AbstractNetworkAlgorithm):
         wedges = []
         nodes = []
         # The initial "weights" are Scores, which need to be translated to weights.
-        weights = list(map(lambda x: 1 - x, weights))
+        weights = list(map(lambda x: -x, weights))
         for edge, weight in zip(edges, weights):
             wedges.append([edge[0], edge[1], weight])
             nodes.extend(list(edge))

--- a/src/konnektor/network_planners/generators/minimal_spanning_tree_network_generator.py
+++ b/src/konnektor/network_planners/generators/minimal_spanning_tree_network_generator.py
@@ -77,11 +77,12 @@ class MinimalSpanningTreeNetworkGenerator(NetworkGenerator):
         """
 
         initial_network = self._initial_edge_lister.generate_ligand_network(components=components)
-        mappings = initial_network.edges
+        mappings = initial_network.graph.edges(data=True)
 
         # Translate Mappings to graphable:
         edge_map = {
-            (components.index(m.componentA), components.index(m.componentB)): m for m in mappings
+            (components.index(componentA), components.index(componentB)): d["object"]
+            for componentA, componentB, d in mappings
         }
         edges = list(edge_map.keys())
         weights = [edge_map[k].annotations["score"] for k in edges]


### PR DESCRIPTION
see here: https://github.com/OpenFreeEnergy/openfe/blob/50b5134a5fd7ba2bbeb91de1a0f1b2de4394edfe/openfe/setup/ligand_network_planning.py#L300-L301

 for the corresponding openfe implementation. by matching this, we preserve the same order, and avoid konnektor choosing a different (equally-scored) MST than openfe.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

## PR Author Checklist
- [ ] add news item if changes are user-facing
- [x] run `pre-commit.ci autofix` when the PR is ready for review

## Tips
* Comment "pre-commit.ci autofix" to have pre-commit.ci auto-format your PR.
  Since this will create a commit, it is best to make this comment when you are finished with your work.

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.


## Reviewer Checklist
- [ ] news entry has been added if necessary
- [ ] pre-commit auto fix has been run
- [ ] any API breaks have been documented
