### PR TITLE
Ensure PEP-639 Support

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -16,7 +16,7 @@ dependencies:
   - gufe
   - typing-extensions
   # Sci
-  - numpy
+  - numpy <2.3  # TypeError: assert_array_almost_equal() got an unexpected keyword argument 'x'
   - scipy
   - networkx
   - scikit-learn

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,9 @@ requires = [
 name = "konnektor"
 description = "Konnektor is a package for calculating networks."
 readme = "README.md"
+license = "MIT"
+license-files = [ "LICENSE" ]
+
 authors = [
   { name = "Benjamin Ries", email = "benjamin-ries@outlook.com" },
   { name = "Hannah Baumann", email = "hannah.baumann@omsf.io" },
@@ -48,8 +51,6 @@ optional-dependencies.test = [
   "pytest-cov[all]",
 ]
 urls."Homepage" = "https://github.com/OpenFreeEnergy/konnektor"
-license = "MIT"
-license-files = ["LICENSE"]
 
 [tool.setuptools.package-data]
 konnektor = [ "**/*.sdf" ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 build-backend = "setuptools.build_meta"
 
 requires = [
-  "setuptools>=64",
+  "setuptools>=77.0.3",
   "setuptools-scm>=8",
 ]
 
@@ -20,7 +20,6 @@ authors = [
 ]
 requires-python = ">=3.10"
 classifiers = [
-  "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.10",
@@ -49,6 +48,8 @@ optional-dependencies.test = [
   "pytest-cov[all]",
 ]
 urls."Homepage" = "https://github.com/OpenFreeEnergy/konnektor"
+license = "MIT"
+license-files = ["LICENSE"]
 
 [tool.setuptools.package-data]
 konnektor = [ "**/*.sdf" ]


### PR DESCRIPTION
Eventually (2026-Feb-18) the license field needs to be a SPDX license expression. The table with a "file" or "text" key is deprecated. As of version 77.0.3, setuptools supports this new format.

See:
https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

## PR Author Checklist
- [ ] add news item if changes are user-facing
- [ ] run `pre-commit.ci autofix` when the PR is ready for review

## Tips
* Comment "pre-commit.ci autofix" to have pre-commit.ci auto-format your PR.
  Since this will create a commit, it is best to make this comment when you are finished with your work.

## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.


## Reviewer Checklist
- [ ] news entry has been added if necessary
- [ ] pre-commit auto fix has been run
- [ ] any API breaks have been documented
