### PR TITLE
address sklearn hdbscan deprecation warning

### DIFF
--- a/src/konnektor/network_planners/generators/clustered_network_generator.py
+++ b/src/konnektor/network_planners/generators/clustered_network_generator.py
@@ -200,7 +200,7 @@ class StarrySkyNetworkGenerator(ClusteredNetworkGenerator):
         scorer,
         clusterer: _AbstractClusterer = ComponentsDiversityClusterer(
             featurize=MorganFingerprintTransformer(),
-            cluster=HDBSCAN(metric="jaccard", min_cluster_size=3, alpha=1 / 2048),
+            cluster=HDBSCAN(metric="jaccard", min_cluster_size=3, alpha=1 / 2048, copy=False),
         ),
         n_processes: int = 1,
         progress: bool = False,


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
addresses the following deprecation warning:

```
lib/python3.12/site-packages/sklearn/cluster/_hdbscan/hdbscan.py:722: FutureWarning: The default value of `copy` will change from False to True in 1.10. Explicitly set a value for `copy` to silence this warning.
```

Through generally I would consider `copy=True` to be safer, here I'm setting `copy=False` to preserve existing behavior, though it seems like our usage is unaffected:

> Currently, it only applies when metric="precomputed", when passing a dense array or a CSR sparse matrix and when algorithm="brute".

https://scikit-learn.org/stable/modules/generated/sklearn.cluster.HDBSCAN.html


<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

## PR Author Checklist
- [x] added news item, or changes are not user-facing
- [x] pre-commit CI passes (comment `pre-commit.ci autofix` to auto-format your PR).

## Tips
* Comment `pre-commit.ci autofix` to have pre-commit.ci auto-format your PR.
  Since this will create a commit, it is best to make this comment when you are finished with your work.

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.


## Reviewer Checklist
- [ ] news entry has been added if necessary
- [ ] pre-commit auto fix has been run
- [ ] any API breaks have been documented
