### PR TITLE
deprecate concatenate_networks standalone function in favor of class methods

### DIFF
--- a/dev/advanced_topics.ipynb
+++ b/dev/advanced_topics.ipynb
@@ -559,16 +559,13 @@
    "source": [
     "# NBVAL_SKIP\n",
     "## Concatenate Sub-Networks\n",
-    "from konnektor.network_tools import concatenate_networks\n",
     "from konnektor.network_planners import MstConcatenator\n",
     "\n",
     "concatenator = MstConcatenator(\n",
     "    mappers=mapper, scorer=combo_scorer, n_connecting_edges=2, n_processes=1\n",
     ")\n",
     "\n",
-    "charged_starry_sky_network = concatenate_networks(\n",
-    "    networks=sub_networks, concatenator=concatenator\n",
-    ")\n",
+    "charged_starry_sky_network = concatenator.concatenate_networks(networks=sub_networks)\n",
     "charged_starry_sky_network.name = \"Starry Sky Network\"\n",
     "charged_starry_sky_network"
    ]

--- a/news/remove_concatenate_networks.rst
+++ b/news/remove_concatenate_networks.rst
@@ -8,13 +8,13 @@
 
 **Deprecated:**
 
-* <news item>
+* ``konnektor.network_tools.concatenate_networks()`` has been deprecated and will be removed in v0.4.0.
+Concatenator class methods should be used directly instead.
+For example, instead of ``network_tools.concatenate_networks(mst_concatenator, list_of_networks)``, use ``mst_concatenator.concatenate_networks(list_of_networks)``.
 
 **Removed:**
 
-* ``konnektor.network_tools.concatenate_networks()`` has been removed.
-Concatenator class methods should be used directly instead.
-For example, instead of ``network_tools.concatenate_networks(mst_concatenator, list_of_networks)``, use ``mst_concatenator.concatenate_networks(list_of_networks)``.
+* <news item>
 
 **Fixed:**
 

--- a/news/remove_concatenate_networks.rst
+++ b/news/remove_concatenate_networks.rst
@@ -1,0 +1,25 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* ``konnektor.network_tools.concatenate_networks()`` has been removed.
+Concatenator class methods should be used directly instead.
+For example, instead of ``network_tools.concatenate_networks(mst_concatenator, list_of_networks)``, use ``mst_concatenator.concatenate_networks(list_of_networks)``.
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/konnektor/__init__.py
+++ b/src/konnektor/__init__.py
@@ -26,7 +26,6 @@ from .network_tools import (
     ComponentsDiversityClusterer,
     ScaffoldClusterer,
     append_component,
-    concatenate_networks,
     delete_transformation,
     merge_networks,
 )
@@ -49,7 +48,6 @@ __all__ = [
     ComponentsDiversityClusterer,
     ScaffoldClusterer,
     append_component,
-    concatenate_networks,
     delete_transformation,
     merge_networks,
     __version__,

--- a/src/konnektor/network_planners/generators/clustered_network_generator.py
+++ b/src/konnektor/network_planners/generators/clustered_network_generator.py
@@ -20,7 +20,7 @@ from konnektor.network_tools.clustering.component_diversity_clustering import (
     ComponentsDiversityClusterer,
 )
 
-from ...network_tools import append_component, concatenate_networks
+from ...network_tools import append_component
 from ...network_tools.clustering._abstract_clusterer import _AbstractClusterer
 from ..concatenators import MstConcatenator
 from ..concatenators._abstract_network_concatenator import NetworkConcatenator
@@ -170,9 +170,7 @@ class ClusteredNetworkGenerator(NetworkGenerator):
         if len(self.sub_networks) == 1:
             concat_network = self.sub_networks[0]
         else:
-            concat_network = concatenate_networks(
-                networks=self.sub_networks, concatenator=self.concatenator
-            )
+            concat_network = self.concatenator(ligand_networks=self.sub_networks)
 
         # step 4: has the clustering a noise cluster
         if -1 in self.clusters:

--- a/src/konnektor/network_tools/__init__.py
+++ b/src/konnektor/network_tools/__init__.py
@@ -4,7 +4,6 @@ from .clustering.scaffold_clustering import ScaffoldClusterer
 from .intermediate_generators.imerge_intermediator import ImergeIntermediator
 from .network_handling import (
     append_component,
-    concatenate_networks,
     delete_component,
     delete_transformation,
     merge_networks,
@@ -17,7 +16,6 @@ __all__ = [
     ScaffoldClusterer,
     ImergeIntermediator,
     append_component,
-    concatenate_networks,
     delete_component,
     delete_transformation,
     merge_networks,

--- a/src/konnektor/network_tools/network_handling/__init__.py
+++ b/src/konnektor/network_tools/network_handling/__init__.py
@@ -1,13 +1,12 @@
 # This code is part of OpenFE and is licensed under the MIT license.
 # For details, see https://github.com/OpenFreeEnergy/konnektor
 
-from .concatenate import append_component, concatenate_networks
+from .concatenate import append_component
 from .delete import delete_component, delete_transformation
 from .merge import merge_networks, merge_two_networks
 
 __all__ = [
     append_component,
-    concatenate_networks,
     delete_component,
     delete_transformation,
     merge_networks,

--- a/src/konnektor/network_tools/network_handling/concatenate.py
+++ b/src/konnektor/network_tools/network_handling/concatenate.py
@@ -2,11 +2,45 @@
 # For details, see https://github.com/OpenFreeEnergy/konnektor
 
 
+import warnings
+from collections.abc import Iterable
+
 from gufe import Component, LigandNetwork
 
 from konnektor.network_planners.concatenators._abstract_network_concatenator import (
     NetworkConcatenator,
 )
+
+
+def concatenate_networks(
+    ligand_networks: Iterable[LigandNetwork], concatenator: NetworkConcatenator
+) -> LigandNetwork:
+    """
+    Concatenate networks, is similar to a union of a set of nodes and edgees,
+    if they are all connected via at least one edge. This means, that  at
+    least one node needs to be present in network1 and network2. If this is
+    not the case, use the network concatenators.
+
+    Parameters
+    ----------
+    networks: Iterable[LigandNetwork]
+        Network 1 for merging
+    concatenator: NetworkConcatenator
+        A network planner, that concatenates networks.
+
+    Returns
+    -------
+    LigandNetwork
+        returns the concatenated network
+    """
+    msg = (
+        "concatenate_networks is deprecated, please use the Concatenator's method instead.",
+        "For Example, instead of network_tools.concatenate_networks(mst_concatenator, list_of_networks)``, use ``mst_concatenator.concatenate_networks(list_of_networks)",
+    )
+    warnings.warn(msg, DeprecationWarning)
+    concat_network = concatenator.concatenate_networks(ligand_networks=ligand_networks)
+
+    return concat_network
 
 
 def append_component(

--- a/src/konnektor/network_tools/network_handling/concatenate.py
+++ b/src/konnektor/network_tools/network_handling/concatenate.py
@@ -1,40 +1,12 @@
 # This code is part of OpenFE and is licensed under the MIT license.
 # For details, see https://github.com/OpenFreeEnergy/konnektor
 
-from collections.abc import Iterable
 
 from gufe import Component, LigandNetwork
 
 from konnektor.network_planners.concatenators._abstract_network_concatenator import (
     NetworkConcatenator,
 )
-
-
-def concatenate_networks(
-    networks: Iterable[LigandNetwork], concatenator: NetworkConcatenator
-) -> LigandNetwork:
-    """
-    Concatenate networks, is similar to a union of a set of nodes and edgees,
-    if they are all connected via at least one edge. This means, that  at
-    least one node needs to be present in network1 and network2. If this is
-    not the case, use the network concatenators.
-
-    Parameters
-    ----------
-    networks: Iterable[LigandNetwork]
-        Network 1 for merging
-    concatenator: NetworkConcatenator
-        A network planner, that concatenates networks.
-
-    Returns
-    -------
-    LigandNetwork
-        returns the concatenated network
-    """
-
-    concat_network = concatenator.concatenate_networks(ligand_networks=networks)
-
-    return concat_network
 
 
 def append_component(

--- a/src/konnektor/tests/network_tools/test_concatenate.py
+++ b/src/konnektor/tests/network_tools/test_concatenate.py
@@ -4,6 +4,7 @@ from konnektor.network_analysis import get_is_connected
 from konnektor.network_planners import MstConcatenator
 from konnektor.network_tools.network_handling.concatenate import (
     append_component,
+    concatenate_networks,
 )
 from konnektor.utils.toy_data import (
     build_n_random_mst_network,
@@ -12,6 +13,30 @@ from konnektor.utils.toy_data import (
     genMapper,
     genScorer,
 )
+
+
+def test_concatenate_deprecated():
+    n_connecting_edges = 1
+    n_compounds = 20
+    n_sub_networks = 2
+    networks = build_n_random_mst_network(
+        n_compounds=n_compounds, sub_networks=n_sub_networks, overlap=0, rand_seed=42
+    )
+    concatenator = MstConcatenator(
+        genMapper(),
+        genScorer(n_scores=n_compounds**2),
+        n_connecting_edges=n_connecting_edges,
+    )
+    with pytest.warns(DeprecationWarning):  # ,match="use the Concatenator's method instead."):
+        new_network = concatenate_networks(concatenator=concatenator, ligand_networks=networks)
+
+        assert len(networks) == n_sub_networks
+        assert len(new_network.nodes) == n_compounds
+        # network edges + the network connecting edges
+        assert len(new_network.edges) == sum(
+            [len(n.edges) for n in networks]
+        ) + n_connecting_edges * sum([i for i in range(1, n_sub_networks)])
+        assert get_is_connected(new_network)
 
 
 @pytest.mark.parametrize("n_sub_networks", [2, 3, 4])

--- a/src/konnektor/tests/network_tools/test_concatenate.py
+++ b/src/konnektor/tests/network_tools/test_concatenate.py
@@ -4,7 +4,6 @@ from konnektor.network_analysis import get_is_connected
 from konnektor.network_planners import MstConcatenator
 from konnektor.network_tools.network_handling.concatenate import (
     append_component,
-    concatenate_networks,
 )
 from konnektor.utils.toy_data import (
     build_n_random_mst_network,
@@ -29,7 +28,7 @@ def test_concatenate_mst_networks(n_sub_networks):
         n_connecting_edges=n_connecting_edges,
     )
 
-    new_network = concatenate_networks(networks, concatenator)
+    new_network = concatenator.concatenate_networks(ligand_networks=networks)
 
     assert len(networks) == n_sub_networks
     assert len(new_network.nodes) == n_compounds


### PR DESCRIPTION
I believe this helper method doesn't actually add any additional functionality, and should be removed.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

## PR Author Checklist
- [x] added news item, or changes are not user-facing
- [x] pre-commit CI passes (comment `pre-commit.ci autofix` to auto-format your PR).

## Tips
* Comment `pre-commit.ci autofix` to have pre-commit.ci auto-format your PR.
  Since this will create a commit, it is best to make this comment when you are finished with your work.

## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.


## Reviewer Checklist
- [ ] news entry has been added if necessary
- [ ] pre-commit auto fix has been run
- [ ] any API breaks have been documented
