### PR TITLE
remove gufe classes from konnektor namespace

### DIFF
--- a/news/remove_gufe_types
+++ b/news/remove_gufe_types
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* ``konnektor.Component``, ``konnektor.ProteinComponent``, and ``konnektor.SmallMoleculeComponent`` have been removed.
+  Please use ``gufe.Component``, ``gufe.ProteinComponent``, and ``gufe.SmallMoleculeComponent``, which are identical, respectively, instead.
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/konnektor/__init__.py
+++ b/src/konnektor/__init__.py
@@ -1,9 +1,6 @@
 # This code is part of OpenFE and is licensed under the MIT license.
 # For details, see https://github.com/OpenFreeEnergy/konnektor
 
-# basic gufe types:
-from gufe import Component, ProteinComponent, SmallMoleculeComponent
-
 from ._version import (
     __version__,
     __version_tuple__,
@@ -32,9 +29,6 @@ from .network_tools import (
 from .visualization import draw_ligand_network as draw_ligand_network
 
 __all__ = [
-    Component,
-    ProteinComponent,
-    SmallMoleculeComponent,
     ClusteredNetworkGenerator,
     CyclicNetworkGenerator,
     HeuristicMaximalNetworkGenerator,


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

We're pre-1.0 and these aren't encouraged in the docs anywhere that I can see, so I'm comfortable pulling these out now and sticking with our convention of keeping these defined as gufe objects (we did this in kartograf already).

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

## PR Author Checklist
- [x] added news item, or changes are not user-facing
- [x] pre-commit CI passes (comment `pre-commit.ci autofix` to auto-format your PR).

## Tips
* Comment `pre-commit.ci autofix` to have pre-commit.ci auto-format your PR.
  Since this will create a commit, it is best to make this comment when you are finished with your work.

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
 we're pre-1.0 release and these aren't used in example notebooks (that I can see),  so I'm comfortable making this change now.

## Reviewer Checklist
- [ ] news entry has been added if necessary
- [ ] pre-commit auto fix has been run
- [ ] any API breaks have been documented
