### PR TITLE
deprecate network_analysis.get_is_connected

### DIFF
--- a/news/deprecate_get_is_connected.rst
+++ b/news/deprecate_get_is_connected.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* Deprecated ``konnektor.network_analysis.get_is_connected()``.
+  Use the ligand_network's `.is_connected() <https://gufe.openfree.energy/en/latest/generated/gufe.ligandnetwork.html#gufe.ligandnetwork.LigandNetwork.is_connected>`_ method instead, which is functionally equivalent (`PR #250 <https://github.com/OpenFreeEnergy/konnektor/pull/250/>`_).
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/konnektor/network_analysis/network_analysis.py
+++ b/src/konnektor/network_analysis/network_analysis.py
@@ -15,6 +15,10 @@ def get_is_connected(ligand_network: LigandNetwork) -> bool:
     """
     Check if the Ligand Network graph is connected.
 
+    .. note ::
+        This function is deprecated, please use the ``.is_connected`` method of the ``ligand_network`` instead.
+        See `gufe.LigandNetwork <https://gufe.openfree.energy/en/latest/generated/gufe.ligandnetwork.html#gufe.ligandnetwork.LigandNetwork.is_connected>`_ docs for more details.
+
     Parameters
     ----------
     ligand_network: LigandNetwork

--- a/src/konnektor/network_analysis/network_analysis.py
+++ b/src/konnektor/network_analysis/network_analysis.py
@@ -236,7 +236,7 @@ def get_transformation_failure_robustness(
         nn = ligand_network
         edges_to_del = [edges[e] for e in rng.choice(len(edges), npics, replace=False)]
         nn = tools.delete_transformation(nn, edges_to_del, must_stay_connected=False)
-        connected.append(float(get_is_connected(nn)))
+        connected.append(float(nn.is_connected()))
 
     # np.mean on list of bools give expected float answer
     r = np.mean(connected)

--- a/src/konnektor/network_analysis/network_analysis.py
+++ b/src/konnektor/network_analysis/network_analysis.py
@@ -20,7 +20,7 @@ def get_is_connected(ligand_network: LigandNetwork) -> bool:
     or that there are separate networks that do not link to each other.
 
     .. note ::
-        This function is deprecated, please use the ``.is_connected`` method of the ``ligand_network`` instead.
+        This function is deprecated. Use the ``.is_connected()`` method of ``ligand_network`` instead.
         See `gufe.LigandNetwork <https://gufe.openfree.energy/en/latest/generated/gufe.ligandnetwork.html#gufe.ligandnetwork.LigandNetwork.is_connected>`_ docs for more details.
 
     Parameters

--- a/src/konnektor/network_analysis/network_analysis.py
+++ b/src/konnektor/network_analysis/network_analysis.py
@@ -11,7 +11,6 @@ from gufe import LigandNetwork, SmallMoleculeComponent
 from .. import network_tools as tools
 
 
-#  TODO: deprecate this?
 def get_is_connected(ligand_network: LigandNetwork) -> bool:
     """
     Check whether all nodes in the LigandNetwork are connected to each other, ignoring edge direction.
@@ -19,7 +18,7 @@ def get_is_connected(ligand_network: LigandNetwork) -> bool:
     A False value indicates that either some nodes have no edges
     or that there are separate networks that do not link to each other.
 
-    .. note ::
+    .. version-deprecated:: 0.4.0
         This function is deprecated. Use the ``.is_connected()`` method of ``ligand_network`` instead.
         See `gufe.LigandNetwork <https://gufe.openfree.energy/en/latest/generated/gufe.ligandnetwork.html#gufe.ligandnetwork.LigandNetwork.is_connected>`_ docs for more details.
 
@@ -33,7 +32,7 @@ def get_is_connected(ligand_network: LigandNetwork) -> bool:
         True if the LigandNetwork is connected, otherwise False.
     """
     msg = "`get_is_connected` is deprecated, please use the ligand_network's `.is_connected()` method instead"
-    warnings.warn(msg, DeprecationWarning)
+    warnings.warn(msg, DeprecationWarning, stacklevel=2)
 
     return ligand_network.is_connected()
 

--- a/src/konnektor/network_analysis/network_analysis.py
+++ b/src/konnektor/network_analysis/network_analysis.py
@@ -2,6 +2,8 @@
 # For details, see https://github.com/OpenFreeEnergy/konnektor
 
 
+import warnings
+
 import networkx as nx
 import numpy as np
 from gufe import LigandNetwork, SmallMoleculeComponent
@@ -22,6 +24,9 @@ def get_is_connected(ligand_network: LigandNetwork) -> bool:
     bool
         if the Ligand Network graph is connected
     """
+    msg = "`get_is_connected` is deprecated, please use the ligand_network's `.is_connected()` method instead"
+    warnings.warn(msg, DeprecationWarning)
+
     return ligand_network.is_connected()
 
 

--- a/src/konnektor/network_tools/network_handling/delete.py
+++ b/src/konnektor/network_tools/network_handling/delete.py
@@ -1,7 +1,5 @@
 from gufe import Component, LigandAtomMapping, LigandNetwork
 
-from ...network_analysis import get_is_connected
-
 
 def delete_transformation(
     network: LigandNetwork,
@@ -35,7 +33,7 @@ def delete_transformation(
 
     new_network = LigandNetwork(edges=filtered_edges, nodes=network.nodes)
 
-    if must_stay_connected and not get_is_connected(new_network):
+    if must_stay_connected and not new_network.is_connected():
         raise RuntimeError("Resulting network is not connected anymore!")
 
     return new_network
@@ -73,7 +71,7 @@ def delete_component(
     filtered_edges = list(filter(f, network.edges))
 
     new_network = LigandNetwork(edges=filtered_edges, nodes=filtered_nodes)
-    if must_stay_connected and not get_is_connected(new_network):
+    if must_stay_connected and not new_network.is_connected():
         raise RuntimeError("Resulting network is not connected anymore!")
 
     return new_network

--- a/src/konnektor/tests/network_planners/concatenators/test_bipartite_MST_connector.py
+++ b/src/konnektor/tests/network_planners/concatenators/test_bipartite_MST_connector.py
@@ -3,7 +3,6 @@
 
 from gufe import LigandNetwork
 
-from konnektor.network_analysis import get_is_connected
 from konnektor.network_planners.concatenators import MstConcatenator
 from konnektor.tests.network_planners.conf import (
     GenAtomMapper,
@@ -26,4 +25,4 @@ def test_mst_network_concatenation(ligand_network_ab):
     assert isinstance(cn, LigandNetwork)
     assert len(cn.nodes) == nA + nB
     assert len(cn.edges) == eA + eB + concatenator.n_connecting_edges
-    assert get_is_connected(cn)
+    assert cn.is_connected()

--- a/src/konnektor/tests/network_planners/generators/test_clustered_network_generator.py
+++ b/src/konnektor/tests/network_planners/generators/test_clustered_network_generator.py
@@ -5,7 +5,7 @@ import numpy as np
 from gufe import LigandNetwork
 from sklearn.cluster import KMeans
 
-from konnektor.network_analysis import get_is_connected, get_network_score
+from konnektor.network_analysis import get_network_score
 from konnektor.network_planners.generators.clustered_network_generator import (
     ClusteredNetworkGenerator,
 )
@@ -41,6 +41,6 @@ def test_clustered_network_planner():
     assert len(planner.clusters) == 3
     expected_number_of_edges = 3 * ((n_compounds // 3) - 1) + (3 * concatenator.n_connecting_edges)
     assert len(ligand_network.edges) == expected_number_of_edges
-    assert get_is_connected(ligand_network)
+    assert ligand_network.is_connected()
 
     np.testing.assert_allclose(get_network_score(ligand_network), 25.708691, rtol=0.05)

--- a/src/konnektor/tests/network_planners/generators/test_cyclic_network_planner.py
+++ b/src/konnektor/tests/network_planners/generators/test_cyclic_network_planner.py
@@ -5,7 +5,6 @@ import numpy as np
 
 from konnektor.network_analysis import (
     get_component_number_cycles,
-    get_is_connected,
     get_network_score,
 )
 from konnektor.network_planners import CyclicNetworkGenerator
@@ -31,7 +30,7 @@ def test_cyclic_network_planner():
     edge_count = n_compounds * 3
     assert len(network.edges) <= edge_count
     assert len(network.edges) > n_compounds
-    assert get_is_connected(network)
+    assert network.is_connected()
     nnode_cycles = get_component_number_cycles(network)
     assert all(v >= ncycles for k, v in nnode_cycles.items())
 

--- a/src/konnektor/tests/network_planners/generators/test_explicit_network_planner.py
+++ b/src/konnektor/tests/network_planners/generators/test_explicit_network_planner.py
@@ -6,7 +6,6 @@ import itertools
 import pytest
 from gufe import LigandNetwork
 
-from konnektor.network_analysis import get_is_connected
 from konnektor.network_planners.generators.explicit_network_generator import (
     ExplicitNetworkGenerator,
 )
@@ -29,7 +28,7 @@ def test_explicit_network_planner():
     result_edges = [(e.componentA, e.componentB) for e in ligand_network.edges]
     assert frozenset(result_edges) == frozenset(edges)
 
-    assert get_is_connected(ligand_network)
+    assert ligand_network.is_connected()
 
 
 def test_explicit_network_planner_from_indices():
@@ -49,7 +48,7 @@ def test_explicit_network_planner_from_indices():
     result_edges = [(int(e.componentA.name), int(e.componentB.name)) for e in ligand_network.edges]
     assert frozenset(result_edges) == frozenset(edges)
 
-    assert get_is_connected(ligand_network)
+    assert ligand_network.is_connected()
 
 
 def test_explicit_network_planner_from_indices_bad_index():
@@ -78,7 +77,7 @@ def test_explicit_network_planner_from_indices_disconnected():
     result_edges = [(int(e.componentA.name), int(e.componentB.name)) for e in ligand_network.edges]
     assert frozenset(result_edges) == frozenset(edges)
 
-    assert not get_is_connected(ligand_network)
+    assert not ligand_network.is_connected()
 
 
 def test_explicit_network_planner_from_names():
@@ -96,7 +95,7 @@ def test_explicit_network_planner_from_names():
     result_edges = [(e.componentA.name, e.componentB.name) for e in ligand_network.edges]
     assert frozenset(result_edges) == frozenset(edges)
 
-    assert get_is_connected(ligand_network)
+    assert ligand_network.is_connected()
 
 
 def test_explicit_network_planner_from_names_bad_name():
@@ -134,7 +133,7 @@ def test_explicit_network_planner_from_names_disconnected():
     result_edges = [(e.componentA.name, e.componentB.name) for e in ligand_network.edges]
     assert frozenset(result_edges) == frozenset(edges)
 
-    assert not get_is_connected(ligand_network)
+    assert not ligand_network.is_connected()
 
 
 def test_explicit_network_planner_invalid_mapper():

--- a/src/konnektor/tests/network_planners/generators/test_heuristic_maximal_network_planner.py
+++ b/src/konnektor/tests/network_planners/generators/test_heuristic_maximal_network_planner.py
@@ -3,7 +3,6 @@
 
 import pytest
 
-from konnektor.network_analysis import get_is_connected
 from konnektor.network_planners import HeuristicMaximalNetworkGenerator
 from konnektor.tests.network_planners.conf import (
     BadMapper,
@@ -33,7 +32,7 @@ def test_generate_maximal_network(with_progress, n_process):
     edge_count = n_compounds * 10
     assert len(network.edges) <= edge_count
     assert len(network.edges) > n_compounds
-    assert get_is_connected(network)
+    assert network.is_connected()
 
 
 @pytest.mark.parametrize("n_process", [1, 2])
@@ -57,7 +56,7 @@ def test_generate_heuristic_maximal_network_no_scorer(n_process):
     edge_count = n_compounds * 3
     assert len(network.edges) <= edge_count
     assert len(network.edges) > n_compounds
-    assert get_is_connected(network)
+    assert network.is_connected()
 
     # it should use the mapping ({0:2}) of the first mapper (BadMultiMapper)
     assert [e.componentA_to_componentB for e in network.edges] == len(network.edges) * [{0: 2}]

--- a/src/konnektor/tests/network_planners/generators/test_nedges_network_planner.py
+++ b/src/konnektor/tests/network_planners/generators/test_nedges_network_planner.py
@@ -4,7 +4,7 @@
 import numpy as np
 from gufe import LigandNetwork
 
-from konnektor.network_analysis import get_is_connected, get_network_score
+from konnektor.network_analysis import get_network_score
 from konnektor.network_planners import NNodeEdgesNetworkGenerator
 from konnektor.tests.network_planners.conf import (
     GenAtomMapper,
@@ -27,6 +27,6 @@ def test_nedges_network_mappers(atom_mapping_basic_test_files):
     assert isinstance(network, LigandNetwork)
     assert len(network.nodes) == len(ligands)
     assert len(network.edges) <= len(ligands) * 2
-    assert get_is_connected(network)
+    assert network.is_connected()
 
     np.testing.assert_allclose(get_network_score(network), 0.933333, rtol=0.01)

--- a/src/konnektor/tests/network_planners/generators/test_starry_sky_network_generator.py
+++ b/src/konnektor/tests/network_planners/generators/test_starry_sky_network_generator.py
@@ -5,7 +5,7 @@ import numpy as np
 from gufe import LigandNetwork
 from sklearn.cluster import KMeans
 
-from konnektor.network_analysis import get_is_connected, get_network_score
+from konnektor.network_analysis import get_network_score
 from konnektor.network_planners.generators.clustered_network_generator import (
     StarrySkyNetworkGenerator,
 )
@@ -35,6 +35,6 @@ def test_starry_sky_network_planner():
     assert isinstance(ligand_network, LigandNetwork)
     assert len(ligand_network.nodes) == n_compounds
     np.testing.assert_allclose(actual=len(ligand_network.edges), desired=approx_edges, rtol=5)
-    assert get_is_connected(ligand_network)
+    assert ligand_network.is_connected()
 
     np.testing.assert_allclose(get_network_score(ligand_network), 26.4454, rtol=0.01)

--- a/src/konnektor/tests/network_planners/generators/test_twin_star_network_planner.py
+++ b/src/konnektor/tests/network_planners/generators/test_twin_star_network_planner.py
@@ -4,7 +4,7 @@
 import numpy as np
 from gufe import LigandNetwork
 
-from konnektor.network_analysis import get_is_connected, get_network_score
+from konnektor.network_analysis import get_network_score
 from konnektor.network_planners import TwinStarNetworkGenerator
 from konnektor.utils.toy_data import build_random_dataset
 
@@ -24,5 +24,5 @@ def test_twin_star_network_planner():
     assert isinstance(ligand_network, LigandNetwork)
     assert len(ligand_network.nodes) == n_compounds
     np.testing.assert_allclose(actual=len(ligand_network.edges), desired=approx_edges, rtol=5)
-    assert get_is_connected(ligand_network)
+    assert ligand_network.is_connected()
     np.testing.assert_allclose(get_network_score(ligand_network), 45.4256, rtol=0.01)

--- a/src/konnektor/tests/network_tools/test_concatenate.py
+++ b/src/konnektor/tests/network_tools/test_concatenate.py
@@ -1,6 +1,5 @@
 import pytest
 
-from konnektor.network_analysis import get_is_connected
 from konnektor.network_planners import MstConcatenator
 from konnektor.network_tools.network_handling.concatenate import (
     append_component,
@@ -36,7 +35,7 @@ def test_concatenate_deprecated():
         assert len(new_network.edges) == sum(
             [len(n.edges) for n in networks]
         ) + n_connecting_edges * sum([i for i in range(1, n_sub_networks)])
-        assert get_is_connected(new_network)
+        assert new_network.is_connected()
 
 
 @pytest.mark.parametrize("n_sub_networks", [2, 3, 4])
@@ -61,7 +60,7 @@ def test_concatenate_mst_networks(n_sub_networks):
     assert len(new_network.edges) == sum(
         [len(n.edges) for n in networks]
     ) + n_connecting_edges * sum([i for i in range(1, n_sub_networks)])
-    assert get_is_connected(new_network)
+    assert new_network.is_connected()
 
 
 def test_append_node():
@@ -81,4 +80,4 @@ def test_append_node():
     assert len(new_network.nodes) == n_compounds
     # network edges + the network connecting edges
     assert len(new_network.edges) == len(network.edges) + n_connecting_edges
-    assert get_is_connected(new_network)
+    assert new_network.is_connected()

--- a/src/konnektor/tests/network_tools/test_merge.py
+++ b/src/konnektor/tests/network_tools/test_merge.py
@@ -1,4 +1,3 @@
-from konnektor.network_analysis import get_is_connected
 from konnektor.network_tools.network_handling.merge import (
     merge_networks,
     merge_two_networks,
@@ -13,7 +12,7 @@ def test_merge_two_mst_networks():
 
     assert len(new_network.nodes) == 20
     assert len(new_network.edges) == 19
-    assert get_is_connected(new_network)
+    assert new_network.is_connected()
 
 
 def test_merge_mst_networks():
@@ -24,7 +23,7 @@ def test_merge_mst_networks():
     assert len(networks) == 2
     assert len(new_network.nodes) == 20
     assert len(new_network.edges) == 19
-    assert get_is_connected(new_network)
+    assert new_network.is_connected()
 
     networks = build_n_random_mst_network(n_compounds=20, sub_networks=4, overlap=1, rand_seed=42)
     new_network = merge_networks(networks)
@@ -32,4 +31,4 @@ def test_merge_mst_networks():
     assert len(networks) == 4
     assert len(new_network.nodes) == 20
     assert len(new_network.edges) == 19
-    assert get_is_connected(new_network)
+    assert new_network.is_connected()

--- a/src/konnektor/tests/network_tools/test_misc.py
+++ b/src/konnektor/tests/network_tools/test_misc.py
@@ -1,6 +1,5 @@
 import pytest
 
-from konnektor.network_analysis import get_is_connected
 from konnektor.network_tools.network_handling.delete import (
     delete_component,
     delete_transformation,
@@ -20,7 +19,7 @@ def test_delete_fc_component():
     assert len(new_network.nodes) == len(network.nodes) - 1
     assert len(new_network.edges) < len(network.edges)
     assert del_node not in new_network.nodes
-    assert get_is_connected(new_network)
+    assert new_network.is_connected()
 
 
 def test_delete_connected_mst_component():
@@ -59,7 +58,7 @@ def test_delete_fc_transformation():
     assert len(new_network.nodes) == len(network.nodes)
     assert len(new_network.edges) == len(network.edges) - 1
     assert del_edge not in new_network.edges
-    assert get_is_connected(new_network)
+    assert new_network.is_connected()
 
 
 def test_delete_connected_mst_transformation():
@@ -81,4 +80,4 @@ def test_delete_mst_transformation():
     assert len(new_network.nodes) == len(network.nodes)
     assert len(new_network.edges) == len(network.edges) - 1
     assert del_edge not in new_network.edges
-    assert not get_is_connected(new_network)
+    assert not new_network.is_connected()

--- a/src/konnektor/tests/test_network_analysis.py
+++ b/src/konnektor/tests/test_network_analysis.py
@@ -22,13 +22,14 @@ from konnektor.utils.toy_data import (
 
 #   Graph Topology related functionalities - Connectivity
 def test_get_is_connected():
-    # Check for connected.
-    g = build_random_mst_network()
-    assert get_is_connected(g)
+    with pytest.warns(DeprecationWarning, match="please use the ligand_network's"):
+        # Check for connected.
+        g = build_random_mst_network()
+        assert get_is_connected(g)
 
-    # Check for disconnected.
-    g_disscon = LigandNetwork(nodes=g.nodes, edges=list(g.edges)[1:])
-    assert get_is_connected(g_disscon) == False  # noqa
+        # Check for disconnected.
+        g_disscon = LigandNetwork(nodes=g.nodes, edges=list(g.edges)[1:])
+        assert get_is_connected(g_disscon) == False  # noqa
 
 
 def test_get_node_connectives():


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
https://github.com/OpenFreeEnergy/konnektor/pull/242/changes#r3325959091
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

## PR Author Checklist
- [x] added news item, or changes are not user-facing
- [x] pre-commit CI passes (comment `pre-commit.ci autofix` to auto-format your PR).

## Tips
* Comment `pre-commit.ci autofix` to have pre-commit.ci auto-format your PR.
  Since this will create a commit, it is best to make this comment when you are finished with your work.

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.


## Reviewer Checklist
- [ ] news entry has been added if necessary
- [ ] pre-commit auto fix has been run
- [ ] any API breaks have been documented
