### PR TITLE
docs: go back to installing gufe from conda-forge

### DIFF
--- a/docs/environment.yaml
+++ b/docs/environment.yaml
@@ -7,11 +7,7 @@ dependencies:
   - typing-extensions
   - numpy
   - networkx
-  # gufe imports, TODO: remove these once we mamba install
-  - msgpack-python
-  - openff-toolkit-base == 0.17.0
-  - openmm
-  - pydantic
+  - gufe >=1.6.1
   - rdkit==2024.03.5
   - ipycytoscape
   - myst-parser
@@ -22,5 +18,3 @@ dependencies:
   - zstandard
   - pip:
     - git+https://github.com/OpenFreeEnergy/ofe-sphinx-theme@a45f3edd5bc3e973c1a01b577c71efa1b62a65d6
-    # pip install gufe so that conda-forge gufe doesn't pull in ambertools and cause a memory error
-    - git+https://github.com/OpenFreeEnergy/gufe@main


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
We had to do a workaround (#183, ambertools causing out-of-memory error for docs builds) until gufe v1.6.1 was released, but now we can install from conda-forge again.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

## PR Author Checklist
- [ ] added news item, or changes are not user-facing
- [x] pre-commit CI passes (comment `pre-commit.ci autofix` to auto-format your PR).

## Tips
* Comment `pre-commit.ci autofix` to have pre-commit.ci auto-format your PR.
  Since this will create a commit, it is best to make this comment when you are finished with your work.

## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.


## Reviewer Checklist
- [ ] news entry has been added if necessary
- [ ] pre-commit auto fix has been run
- [ ] any API breaks have been documented
