### PR TITLE
Remove `initial_edge_lister` from the concatenators

### DIFF
--- a/src/konnektor/network_planners/concatenators/_abstract_network_concatenator.py
+++ b/src/konnektor/network_planners/concatenators/_abstract_network_concatenator.py
@@ -25,7 +25,6 @@ class NetworkConcatenator(NetworkPlanner):
         scorer: Callable[[AtomMapping], float] | None,
         network_generator: _AbstractNetworkAlgorithm | None,
         n_processes: int = 1,
-        _initial_edge_lister=None,
     ):
         """Abstract class for network concatenation, not to be called directly.
 
@@ -37,23 +36,12 @@ class NetworkConcatenator(NetworkPlanner):
             Callable which takes a AtomMapping and returns a float in [0,1].
         n_processes: int, optional
             Number of processes that can be used for the network generation, by default 1.
-        _initial_edge_lister: NetworkConcatenator | None, optional
-            The NetworkConcatenator to use if the NetworkConcatenator requires an initial set of edges, by default None.
         """
 
         super().__init__(mappers=mappers, scorer=scorer)
 
         self.network_generator = network_generator
         self.n_processes = n_processes
-        self._initial_edge_lister = _initial_edge_lister
-
-        # pass on the parallelization to the edge lister
-        # edge listing is usually the most expensive task,
-        # so parallelization is important here.
-        if self._initial_edge_lister is not None and hasattr(
-            self._initial_edge_lister, "nprocesses"
-        ):
-            self.n_processes = n_processes
 
     def __call__(self, *args, **kwargs) -> LigandNetwork:
         return self.concatenate_networks(*args, **kwargs)

--- a/src/konnektor/network_planners/concatenators/cyclic_concatenator.py
+++ b/src/konnektor/network_planners/concatenators/cyclic_concatenator.py
@@ -22,7 +22,6 @@ class CyclicConcatenator(NetworkConcatenator):
         n_connecting_cycles: int = 2,
         cycle_sizes: int | list[int] = 3,
         n_processes: int = 1,
-        _initial_edge_lister: NetworkConcatenator | None = None,
     ):
         """
         NOTE: This class has not yet been implemented.
@@ -40,15 +39,7 @@ class CyclicConcatenator(NetworkConcatenator):
             Size of the cycles to build, can be an int or range of ints, by default 3.
         n_processes: int, optional
             Number of processes that can be used for the network generation, by default 1.
-        _initial_edge_lister: NetworkConcatenator | None, optional
-            The NetworkConcatenator to use if the NetworkConcatenator requires an initial set of edges.
         """
-        # TODO: this needs to be assigned to self._initial_edge_lister to actually get used.
-        if _initial_edge_lister is None:
-            _initial_edge_lister = MaxConcatenator(
-                mappers=mappers, scorer=scorer, n_processes=n_processes
-            )
-
         super().__init__(
             mappers=mappers,
             scorer=scorer,

--- a/src/konnektor/network_planners/concatenators/cyclic_concatenator.py
+++ b/src/konnektor/network_planners/concatenators/cyclic_concatenator.py
@@ -8,7 +8,6 @@ from gufe import AtomMapper, AtomMapping, LigandNetwork
 
 from .._networkx_implementations import MstNetworkAlgorithm
 from ._abstract_network_concatenator import NetworkConcatenator
-from .max_concatenator import MaxConcatenator
 
 log = logging.getLogger(__name__)
 

--- a/src/konnektor/network_planners/concatenators/max_concatenator.py
+++ b/src/konnektor/network_planners/concatenators/max_concatenator.py
@@ -23,7 +23,6 @@ class MaxConcatenator(NetworkConcatenator):
     ):
         """
         A NetworkConcatenator that connects a set of LigandNetworks with all possible edges.
-        This is usually most useful for initial edge listing.
 
         Parameters
         ----------

--- a/src/konnektor/network_planners/concatenators/mst_concatenator.py
+++ b/src/konnektor/network_planners/concatenators/mst_concatenator.py
@@ -20,7 +20,6 @@ class MstConcatenator(NetworkConcatenator):
         mappers: AtomMapper | Iterable[AtomMapper] | None,
         scorer: Callable[[AtomMapping], float],
         n_processes: int = 1,
-        _initial_edge_lister: NetworkConcatenator | None = None,  # TODO: remove this
     ):
         """
         A NetworkConcatenator that connects subnetworks by treating each
@@ -41,7 +40,6 @@ class MstConcatenator(NetworkConcatenator):
             scorer=scorer,
             network_generator=MstNetworkAlgorithm(),
             n_processes=n_processes,
-            _initial_edge_lister=_initial_edge_lister,
         )
 
     def _score_pair_edges(


### PR DESCRIPTION
The `initial_edge_lister` is not used by the Concatenators, those are using `_score_inter_network_edges` to get all the potential edges. I don't think even if we implemented the CyclicConcatenator we would need this, but if others disagree, I can also just remove it from the MSTConcatenator for now.

Fixes

- https://github.com/OpenFreeEnergy/konnektor/issues/240
- https://github.com/OpenFreeEnergy/konnektor/issues/243

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

## LLM / AI generated code disclosure
<!-- Please update this disclosure to reflect if you did or did not use LLMs / AI to generate code -->
LLMs or other AI-powered tools (beyond simple IDE use cases) were used in this contribution: no
If yes, please provide details here:

## PR Author Checklist
- [x] added news item, or changes are not user-facing
- [x] pre-commit CI passes (comment `pre-commit.ci autofix` to auto-format your PR).
- [x] filled in the AI-generated code disclosure.

## Tips
* Comment `pre-commit.ci autofix` to have pre-commit.ci auto-format your PR.
  Since this will create a commit, it is best to make this comment when you are finished with your work.

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.


## Reviewer Checklist
- [ ] news entry has been added if necessary
- [ ] pre-commit auto fix has been run
- [ ] any API breaks have been documented
